### PR TITLE
Fix stream piping

### DIFF
--- a/universal-renderer/src/fastify/handlers/stream.ts
+++ b/universal-renderer/src/fastify/handlers/stream.ts
@@ -93,8 +93,8 @@ export function createStreamHandler<TContext extends Record<string, any>>(
                   reply.raw.end(tail);
                 });
               } else {
-                pipe(reply.raw);
                 const streamCompleter = new PassThrough();
+                streamCompleter.pipe(reply.raw, { end: false });
                 streamCompleter.on("end", () => {
                   if (!reply.raw.writableEnded) {
                     reply.raw.end(tail);


### PR DESCRIPTION
## Summary
- remove duplicate pipe call for Fastify stream handler
- pipe PassThrough to reply before piping React stream

## Testing
- `npm --workspace universal-renderer run test`

------
https://chatgpt.com/codex/tasks/task_e_683f8dc4e06c8329a9de07c8ef5362a4