### PR TITLE
Move Fastify & uWS to peer deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,9 +16,7 @@
     "universal-renderer": {
       "name": "universal-renderer",
       "version": "0.5.0",
-      "dependencies": {
-        "fastify": "^5.3.3",
-      },
+      "dependencies": {},
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.0",
         "@testing-library/react": "^15.0.0",
@@ -40,6 +38,8 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "vite": "^6.3.5",
+        "fastify": "^5.3.3",
+        "uwebsockets.js": "*",
       },
     },
   },

--- a/universal-renderer/README.md
+++ b/universal-renderer/README.md
@@ -14,6 +14,8 @@ npm install universal-renderer
 npm install express   # For Express.js
 npm install hono      # For Hono
 npm install bun       # For Bun (usually Bun is the runtime, ensure @types/bun for TS)
+npm install fastify   # For Fastify
+npm install uwebsockets.js # For uWebSockets.js
 ```
 
 ## Examples

--- a/universal-renderer/package.json
+++ b/universal-renderer/package.json
@@ -57,7 +57,9 @@
     "react-dom": "^19.1.0",
     "vite": "^6.3.5",
     "express": "^4.18.0",
-    "hono": "^4.0.0"
+    "hono": "^4.0.0",
+    "fastify": "^5.3.3",
+    "uwebsockets.js": "*"
   },
   "devDependencies": {
     "@types/bun": "^1.1.6",
@@ -86,7 +88,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "fastify": "^5.3.3"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
## Summary
- shift Fastify and uWebSockets.js to peer dependencies
- update documentation to mention installing Fastify or uWebSockets.js

## Testing
- `npx vitest run` *(fails: `npm error canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_683f8db903548329b1965375cdb36ec7