### PR TITLE
[build] emit uwebsocket server

### DIFF
--- a/universal-renderer/tsdown.config.ts
+++ b/universal-renderer/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "src/hono/index.ts",
     "src/bun/index.ts",
     "src/fastify/index.ts",
+    "src/uwebsocket/index.ts",
   ],
   format: ["esm", "cjs"],
   dts: true,


### PR DESCRIPTION
## Summary
- update tsdown config so uwebsocket server is built

## Testing
- `bun run --filter universal-renderer test`
- `bundle exec rspec spec/units`
- `bundle exec rspec` *(fails: Template missing <!-- SSR_BODY --> marker)*
- `bun run --filter universal-renderer build`
- `bun x prettier --check .` *(fails: missing @prettier/plugin-ruby)*
- `bundle exec rubocop`

------
https://chatgpt.com/codex/tasks/task_e_683f924d507483298f44ce5ff286508c