### PR TITLE
[express] Add cluster helper

### DIFF
--- a/universal-renderer/src/express/cluster.test.ts
+++ b/universal-renderer/src/express/cluster.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.restoreAllMocks();
+});
+
+describe("startCluster", () => {
+  it("forks workers when primary", async () => {
+    const fork = vi.fn();
+    const on = vi.fn();
+    vi.doMock("node:cluster", () => ({
+      default: { isPrimary: true, fork, on },
+    }));
+    const { startCluster } = await import("./cluster");
+    const app = { listen: vi.fn() } as any;
+    startCluster(app, { workers: 2, port: 4000 });
+    expect(fork).toHaveBeenCalledTimes(2);
+    expect(on).toHaveBeenCalledWith("exit", expect.any(Function));
+    expect(app.listen).not.toHaveBeenCalled();
+  });
+
+  it("starts server when worker", async () => {
+    const listen = vi.fn((_p, _h, cb) => cb && cb());
+    const fork = vi.fn();
+    const on = vi.fn();
+    vi.doMock("node:cluster", () => ({
+      default: { isPrimary: false, worker: { id: 1 }, fork, on },
+    }));
+    const { startCluster } = await import("./cluster");
+    const app = { listen } as any;
+    startCluster(app, { port: 3000, host: "127.0.0.1" });
+    expect(listen).toHaveBeenCalledWith(
+      3000,
+      "127.0.0.1",
+      expect.any(Function),
+    );
+    expect(fork).not.toHaveBeenCalled();
+  });
+});

--- a/universal-renderer/src/express/cluster.ts
+++ b/universal-renderer/src/express/cluster.ts
@@ -1,0 +1,29 @@
+import cluster from "node:cluster";
+import { availableParallelism } from "node:os";
+import type express from "express";
+
+export type ClusterOptions = {
+  port?: number;
+  host?: string;
+  workers?: number;
+};
+
+export function startCluster(
+  app: express.Application,
+  options?: ClusterOptions,
+): void {
+  const workers = options?.workers ?? availableParallelism();
+  const port = options?.port ?? Number(process.env.PORT ?? 3000);
+  const host = options?.host ?? "0.0.0.0";
+
+  if (cluster.isPrimary) {
+    for (let i = 0; i < workers; i++) cluster.fork();
+    cluster.on("exit", () => cluster.fork());
+    return;
+  }
+
+  app.listen(port, host, () => {
+    const id = cluster.worker?.id ?? process.pid;
+    console.log(`[${id}] listening on ${host}:${port}`);
+  });
+}

--- a/universal-renderer/src/express/index.ts
+++ b/universal-renderer/src/express/index.ts
@@ -16,3 +16,4 @@ export type {
   ExpressSSRHandlerOptions,
   ExpressStreamHandlerOptions,
 } from "./types";
+export { startCluster } from "./cluster";


### PR DESCRIPTION
## Summary
- add startCluster helper for parallel Express workers
- export helper from the Express entrypoint
- test cluster for primary and worker modes

## Testing
- `bun run --filter universal-renderer build`
- `bun run --filter universal-renderer test`
- `bundle exec rspec` *(fails: Run options: include {focus: true} ...)*

------
https://chatgpt.com/codex/tasks/task_e_683fd3b446688329907fee3ac6dd8c11