### PR TITLE
Add streaming SSR support to stdio adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Configure in `config/initializers/universal_renderer.rb`:
 ```ruby
 UniversalRenderer.configure do |config|
   # Choose your SSR engine:
-  # :http           - External Node.js server (default, supports streaming)
-  # :stdio          - Stdio Bun processes via Open3 (no streaming, no external server)
+  # :http           - External Node.js server (default)
+  # :stdio          - Stdio Bun processes via Open3 (no external server)
+  # Both engines support blocking and streaming SSR.
   config.engine = :http
   # To select per environment:
   # config.engine = Rails.env.production? ? :stdio : :http
@@ -93,10 +94,10 @@ The Stdio engine maintains a pool of stdio Bun processes and communicates with t
 - Eliminates network overhead
 - Simplified deployment
 - Better for simple SSR needs
+- Streaming SSR support (requires `streamCallbacks` in the stdio renderer)
 
 **Cons:**
 
-- No streaming support
 - Memory overhead per long-lived process
 - Not suitable for complex JavaScript applications
 

--- a/examples/universal_renderer_demo/Procfile.dev
+++ b/examples/universal_renderer_demo/Procfile.dev
@@ -1,3 +1,3 @@
 web: bundle exec rails server
 vite: bun run dev
-ssr: bun run ssr:dev:http
+# ssr: bun run ssr:dev:http

--- a/examples/universal_renderer_demo/app/controllers/home_controller.rb
+++ b/examples/universal_renderer_demo/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
   include UniversalRenderer::Renderable
 
-  enable_ssr
+  enable_ssr streaming: true
 
   def index
     records = params.fetch(:records, "100").to_i.clamp(1, 2_000)

--- a/examples/universal_renderer_demo/app/frontend/ssr/stdio.tsx
+++ b/examples/universal_renderer_demo/app/frontend/ssr/stdio.tsx
@@ -1,5 +1,5 @@
 import setup from "@/ssr/setup";
-import { head } from "@/ssr/utils";
+import { head, transform } from "@/ssr/utils";
 import { renderToString } from "react-dom/server.node";
 import { createRenderer } from "../../../../../universal-renderer/src/stdio";
 
@@ -22,5 +22,10 @@ await createRenderer({
 
   error: (err) => {
     console.error(`${err.message}\n${err.stack}`);
+  },
+
+  streamCallbacks: {
+    head,
+    transform,
   },
 });

--- a/lib/universal_renderer/adapter/base.rb
+++ b/lib/universal_renderer/adapter/base.rb
@@ -14,7 +14,7 @@ module UniversalRenderer
         raise NotImplementedError, "Subclasses must implement #call"
       end
 
-      # Performs streaming SSR (only supported by HTTP adapter)
+      # Performs streaming SSR
       # @param url [String] The URL of the page to render
       # @param props [Hash] Props to be passed for rendering
       # @param template [String] The HTML template to use for rendering

--- a/lib/universal_renderer/adapter/stdio.rb
+++ b/lib/universal_renderer/adapter/stdio.rb
@@ -49,15 +49,40 @@ module UniversalRenderer
         nil
       end
 
-      def stream(_url, _props, _template, _response)
-        Rails.logger.warn(
-          "Stdio adapter does not support streaming SSR. Use HTTP adapter for streaming."
+      def stream(url, props, template, response)
+        return false unless @process_pool
+
+        chunks_written = false
+
+        with_process do |process|
+          Rails.logger.debug do
+            "Stdio streaming: #{url} with props keys: #{props.keys}"
+          end
+
+          process.render_stream(url, props, template) do |chunk|
+            response.stream.write(chunk)
+            chunks_written = true
+          end
+        end
+
+        true
+      rescue StandardError => e
+        Rails.logger.error(
+          "Stdio SSR stream failed (URL: #{url}): #{e.full_message}"
         )
-        false
+
+        # Once bytes have reached the response stream a fallback render would
+        # append a second document to the same response, so close what we have
+        # and report success. A failure before any output allows a clean
+        # fallback to non-streaming rendering.
+        return false unless chunks_written
+
+        response.stream.close unless response.stream.closed?
+        true
       end
 
       def supports_streaming?
-        false
+        !@process_pool.nil?
       end
 
       private
@@ -102,7 +127,18 @@ module UniversalRenderer
       # the pool guarantees exclusive checkout so no internal locking is needed.
       # On I/O error, timeout, protocol desync, or unexpected child exit, the
       # underlying process is respawned so the pool slot remains usable.
-      class StdioProcess
+      class StdioProcess # rubocop:disable Metrics/ClassLength
+        # Raised when the child reports a render failure in-band via a
+        # terminal `{"error": ...}` frame. The protocol stream remains
+        # synchronized, so the process is not respawned.
+        class RenderError < StandardError
+        end
+
+        # Raised when the child emits a frame the streaming protocol does not
+        # define; the stream must be considered desynchronized.
+        class ProtocolError < StandardError
+        end
+
         def initialize(cli_script, timeout_ms: 5_000)
           @cli_script = cli_script
           @timeout = timeout_ms / 1000.0
@@ -124,6 +160,40 @@ module UniversalRenderer
           # means the protocol stream is desynchronized (e.g. a stray stdout
           # write in the child); leftover bytes in the pipe would be served as
           # the next request's response, so the process must be replaced too.
+          close
+          raise e
+        end
+
+        # Stream a page render, yielding each HTML chunk as the child emits
+        # it. The child answers with `{"chunk": ...}` frames terminated by
+        # `{"done": true}` on success or `{"error": ...}` on failure (raised
+        # as RenderError). The read deadline applies per frame, so a long
+        # render survives as long as the child never goes idle past the
+        # timeout.
+        def render_stream(url, props, template)
+          spawn! unless alive?
+
+          payload = JSON.generate({ url: url, props: props, template: template })
+          write_line_with_deadline(payload)
+
+          loop do
+            frame = JSON.parse(read_line_with_deadline)
+
+            if frame.key?("error")
+              raise RenderError, frame["error"]
+            elsif frame.key?("chunk") || frame.key?("done")
+              yield frame["chunk"] if frame["chunk"]
+              return true if frame["done"]
+            else
+              raise ProtocolError,
+                    "Unexpected stdio frame with keys: #{frame.keys.inspect}"
+            end
+          end
+        rescue Timeout::Error,
+               Errno::EPIPE,
+               IOError,
+               JSON::ParserError,
+               ProtocolError => e
           close
           raise e
         end
@@ -150,7 +220,7 @@ module UniversalRenderer
         # has wedged without exiting.
         def write_line_with_deadline(payload)
           deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
-          data = payload + "\n"
+          data = "#{payload}\n"
           until data.empty?
             remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
             raise Timeout::Error, "Stdio write timed out after #{@timeout}s" if remaining <= 0
@@ -170,10 +240,19 @@ module UniversalRenderer
         # deadline across multiple partial reads. wait_readable alone only guarantees
         # the first byte is available; a child that writes a partial line and hangs
         # would otherwise block readline indefinitely.
+        #
+        # Bytes past the newline are kept in @read_buffer for the next call:
+        # during streaming several frames routinely arrive in one pipe read.
         def read_line_with_deadline
           deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + @timeout
-          buffer = +""
           loop do
+            nl = @read_buffer.index("\n")
+            if nl
+              line = @read_buffer.byteslice(0, nl)
+              @read_buffer = @read_buffer.byteslice((nl + 1)..)
+              return line
+            end
+
             remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
             raise Timeout::Error, "Stdio render timed out after #{@timeout}s" if remaining <= 0
 
@@ -187,9 +266,7 @@ module UniversalRenderer
             when nil
               raise EOFError, "Stdio child closed stdout"
             else
-              buffer << chunk
-              nl = buffer.index("\n")
-              return buffer.byteslice(0, nl) if nl
+              @read_buffer << chunk
             end
           end
         end
@@ -217,6 +294,9 @@ module UniversalRenderer
           close if @wait_thr
           @stdin, @stdout, @stderr, @wait_thr = Open3.popen3("bun", @cli_script)
           @stdin.sync = true
+          # Binary so String#index positions match byteslice offsets; chunks
+          # from read_nonblock arrive as ASCII-8BIT anyway.
+          @read_buffer = String.new(encoding: Encoding::BINARY)
           drain_stderr!
         end
 

--- a/spec/fixtures/stdio_renderer.ts
+++ b/spec/fixtures/stdio_renderer.ts
@@ -1,5 +1,6 @@
 // Minimal renderer used by spec/integration/stdio_pipe_spec.rb to exercise
 // the real stdin/stdout protocol against a live Bun child process.
+import { createElement } from "react";
 import { createRenderer } from "../../universal-renderer/src/stdio";
 
 await createRenderer({
@@ -16,5 +17,23 @@ await createRenderer({
       body: `<div>${props.content ?? url}</div>`,
       bodyAttrs: { "data-echo": "yes" },
     };
+  },
+
+  streamCallbacks: {
+    node: ({ props }) => {
+      if (props.stream_fail) {
+        return createElement(() => {
+          throw new Error("intentional stream failure");
+        });
+      }
+
+      return createElement(
+        "div",
+        { id: "stream" },
+        String(props.content ?? "streamed"),
+      );
+    },
+
+    head: ({ props }) => `<title>${props.title ?? "stream-fixture"}</title>`,
   },
 });

--- a/spec/integration/integration_environment.rb
+++ b/spec/integration/integration_environment.rb
@@ -84,6 +84,13 @@ module IntegrationEnvironment
         "body_attrs" => {}
       }
     )
+    allow(mock_bun_process).to receive(:render_stream) do |_url, _props, _template, &block|
+      block.call("<html>")
+      block.call("chunk-1")
+      block.call("chunk-2")
+      block.call("</html>")
+      true
+    end
 
     # Mock the process pool
     mock_pool = instance_double(ConnectionPool)

--- a/spec/integration/multi_engine_contract_spec.rb
+++ b/spec/integration/multi_engine_contract_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Multi-Engine Contract Integration", type: :integration do
     end
 
     it_behaves_like "SSR contract compliance", :stdio
-    it_behaves_like "non-streaming adapter"
+    it_behaves_like "stdio streaming support"
 
     describe "STDIO-specific features" do
       it "uses the correct adapter" do

--- a/spec/integration/shared_examples/contract_examples.rb
+++ b/spec/integration/shared_examples/contract_examples.rb
@@ -168,17 +168,29 @@ RSpec.shared_examples "streaming SSR support" do
   end
 end
 
-RSpec.shared_examples "non-streaming adapter" do
-  describe "streaming limitations" do
-    it "does not support streaming" do
-      adapter = UniversalRenderer::AdapterFactory.adapter
-      expect(adapter.supports_streaming?).to be false
+RSpec.shared_examples "stdio streaming support" do
+  describe "streaming" do
+    let(:stream_io) { StringIO.new }
+    let(:response) do
+      stream = stream_io
+      stream_double = double("stream")
+      allow(stream_double).to receive(:write) { |chunk| stream.write(chunk) }
+      allow(stream_double).to receive(:closed?).and_return(false)
+      allow(stream_double).to receive(:close)
+      double("response", stream: stream_double)
     end
 
-    it "returns false when attempting to stream" do
+    it "supports streaming" do
       adapter = UniversalRenderer::AdapterFactory.adapter
-      result = adapter.stream("url", {}, "template", double("response"))
-      expect(result).to be false
+      expect(adapter.supports_streaming?).to be true
+    end
+
+    it "relays streamed chunks into the response stream" do
+      adapter = UniversalRenderer::AdapterFactory.adapter
+      result = adapter.stream("http://example.com/x", {}, "template", response)
+
+      expect(result).to be true
+      expect(stream_io.string).to eq("<html>chunk-1chunk-2</html>")
     end
   end
 end

--- a/spec/integration/stdio_pipe_spec.rb
+++ b/spec/integration/stdio_pipe_spec.rb
@@ -42,4 +42,76 @@ RSpec.describe UniversalRenderer::Adapter::Stdio::StdioProcess do
     expect(result["error"]).to eq("intentional failure")
     expect(result["body"]).to eq("")
   end
+
+  describe "#render_stream" do
+    let(:template) do
+      "<html><head><!-- SSR_HEAD --></head>" \
+        "<body><!-- SSR_BODY --></body></html>"
+    end
+
+    it "streams template head, rendered chunks, and tail in order" do
+      chunks = []
+      result =
+        process.render_stream(
+          "http://example.com/stream",
+          { "content" => "streamed content" },
+          template
+        ) { |chunk| chunks << chunk }
+
+      html = chunks.join
+      expect(result).to be(true)
+      expect(chunks.length).to be >= 2
+      expect(html).to start_with("<html><head><title>stream-fixture</title>")
+      expect(html).to include("streamed content")
+      expect(html).to end_with("</body></html>")
+    end
+
+    it "raises RenderError when the shell fails, leaving the process usable" do
+      chunks = []
+      expect do
+        process.render_stream(
+          "http://example.com/stream-fail",
+          { "stream_fail" => true },
+          template
+        ) { |chunk| chunks << chunk }
+      end.to raise_error(described_class::RenderError, /intentional stream failure/)
+      expect(chunks).to be_empty
+
+      # The error frame is terminal, so the pipe is still synchronized.
+      result = process.render("http://example.com/after", { "content" => "ok" })
+      expect(result["body"]).to eq("<div>ok</div>")
+    end
+
+    it "raises RenderError when the template lacks the body marker" do
+      chunks = []
+      expect do
+        process.render_stream("http://example.com/x", {}, "<html></html>") do |chunk|
+          chunks << chunk
+        end
+      end.to raise_error(described_class::RenderError, /SSR_BODY/)
+      expect(chunks).to be_empty
+    end
+
+    it "interleaves streaming and static renders without desyncing" do
+      stream_html = []
+      process.render_stream(
+        "http://example.com/a",
+        { "content" => "first stream" },
+        template
+      ) { |chunk| stream_html << chunk }
+
+      static_result = process.render("http://example.com/b", { "content" => "static" })
+
+      second_stream = []
+      process.render_stream(
+        "http://example.com/c",
+        { "content" => "second stream" },
+        template
+      ) { |chunk| second_stream << chunk }
+
+      expect(stream_html.join).to include("first stream")
+      expect(static_result["body"]).to eq("<div>static</div>")
+      expect(second_stream.join).to include("second stream")
+    end
+  end
 end

--- a/spec/units/adapter/stdio_spec.rb
+++ b/spec/units/adapter/stdio_spec.rb
@@ -151,22 +151,103 @@ RSpec.describe UniversalRenderer::Adapter::Stdio do
 
   describe "#stream" do
     let(:adapter) { described_class.new }
+    let(:url) { "http://example.com/test" }
+    let(:template) { "<html><!-- SSR_BODY --></html>" }
 
-    it "does not support streaming and returns false" do
-      expect(Rails.logger).to receive(:warn).with(
-        /Stdio adapter does not support streaming/,
-      )
+    def build_response(io)
+      stream_double = double("stream")
+      allow(stream_double).to receive(:write) { |chunk| io.write(chunk) }
+      allow(stream_double).to receive(:closed?).and_return(false)
+      allow(stream_double).to receive(:close)
+      double("response", stream: stream_double)
+    end
 
-      result = adapter.stream("url", {}, "template", double("response"))
-      expect(result).to be false
+    context "when process pool is available" do
+      let(:process_mock) { instance_double(UniversalRenderer::Adapter::Stdio::StdioProcess) }
+      let(:pool_mock) { instance_double(ConnectionPool) }
+
+      before do
+        allow(File).to receive(:exist?).with(
+          Pathname.new("/fake/rails/root").join(cli_script),
+        ).and_return(true)
+
+        allow(ConnectionPool).to receive(:new).and_return(pool_mock)
+        allow(UniversalRenderer::Adapter::Stdio::StdioProcess).to receive(:new).and_return(
+          process_mock,
+        )
+        allow(pool_mock).to receive(:with).and_yield(process_mock)
+      end
+
+      it "writes streamed chunks to the response and returns true" do
+        allow(process_mock).to receive(:render_stream) do |_url, _props, _template, &block|
+          block.call("<html>")
+          block.call("<div>streamed</div>")
+          block.call("</html>")
+          true
+        end
+
+        io = StringIO.new
+        result = adapter.stream(url, {}, template, build_response(io))
+
+        expect(result).to be true
+        expect(io.string).to eq("<html><div>streamed</div></html>")
+      end
+
+      it "returns false when the stream fails before any chunk is written" do
+        allow(process_mock).to receive(:render_stream).and_raise(
+          UniversalRenderer::Adapter::Stdio::StdioProcess::RenderError.new("boom"),
+        )
+
+        expect(Rails.logger).to receive(:error).with(/Stdio SSR stream failed/)
+
+        result = adapter.stream(url, {}, template, build_response(StringIO.new))
+        expect(result).to be false
+      end
+
+      it "closes the response and returns true when the stream fails mid-flight" do
+        allow(process_mock).to receive(:render_stream) do |_url, _props, _template, &block|
+          block.call("<html>")
+          raise Timeout::Error, "stalled"
+        end
+
+        expect(Rails.logger).to receive(:error).with(/Stdio SSR stream failed/)
+
+        io = StringIO.new
+        response = build_response(io)
+        expect(response.stream).to receive(:close)
+
+        result = adapter.stream(url, {}, template, response)
+        expect(result).to be true
+        expect(io.string).to eq("<html>")
+      end
+    end
+
+    context "when process pool is not available" do
+      it "returns false" do
+        result = adapter.stream(url, {}, template, build_response(StringIO.new))
+        expect(result).to be false
+      end
     end
   end
 
   describe "#supports_streaming?" do
-    let(:adapter) { described_class.new }
+    context "when process pool is available" do
+      before do
+        allow(File).to receive(:exist?).with(
+          Pathname.new("/fake/rails/root").join(cli_script),
+        ).and_return(true)
+        allow(ConnectionPool).to receive(:new).and_return(double("pool"))
+      end
 
-    it "returns false" do
-      expect(adapter.supports_streaming?).to be false
+      it "returns true" do
+        expect(described_class.new.supports_streaming?).to be true
+      end
+    end
+
+    context "when process pool is not available" do
+      it "returns false" do
+        expect(described_class.new.supports_streaming?).to be false
+      end
     end
   end
 end

--- a/universal-renderer/README.md
+++ b/universal-renderer/README.md
@@ -74,7 +74,10 @@ Point the gem at `http://localhost:3001` and you're done.
 
 ## Framework Support
 
-Universal Renderer supports Express HTTP and stdio runtimes.
+Universal Renderer supports Express HTTP and stdio runtimes. Both support
+streaming SSR: pass `streamCallbacks` to `createServer` (HTTP) or
+`createRenderer` (stdio) and enable `enable_ssr streaming: true` in the Rails
+controller.
 
 ### Options
 

--- a/universal-renderer/src/stdio/index.test.ts
+++ b/universal-renderer/src/stdio/index.test.ts
@@ -1,5 +1,6 @@
+import { createElement } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { createLineHandler } from "./index";
+import { createLineHandler, createStreamLineHandler } from "./index";
 
 describe("stdio line handler", () => {
   it("throws when setup callback is missing", () => {
@@ -148,5 +149,141 @@ describe("stdio line handler", () => {
 
     expect(parsed.body).toBe("ok");
     expect(onError).toHaveBeenCalledOnce();
+  });
+});
+
+describe("stdio stream handler", () => {
+  const TEMPLATE =
+    "<html><head><!-- SSR_HEAD --></head><body><!-- SSR_BODY --></body></html>";
+
+  function makeHandler(overrides: Record<string, any> = {}) {
+    return createStreamLineHandler({
+      setup: (url: string, props: any) => ({ url, props }),
+      render: () => ({ body: "unused static path" }),
+      streamCallbacks: {
+        node: (context: any) => createElement("div", null, context.url),
+      },
+      ...overrides,
+    });
+  }
+
+  async function collectFrames(
+    handle: ReturnType<typeof makeHandler>,
+    payload: Record<string, any>,
+  ) {
+    const lines: string[] = [];
+    await handle(payload as any, (line) => lines.push(line));
+    return lines.map((line) => {
+      expect(line).not.toContain("\n");
+      return JSON.parse(line);
+    });
+  }
+
+  it("throws when streamCallbacks are missing", () => {
+    expect(() =>
+      createStreamLineHandler({
+        setup: () => ({}),
+        render: () => ({ body: "x" }),
+      }),
+    ).toThrow("streamCallbacks are required");
+  });
+
+  it("emits chunk frames terminated by a done frame", async () => {
+    const frames = await collectFrames(makeHandler(), {
+      url: "/page",
+      template: TEMPLATE,
+    });
+
+    expect(frames.at(-1)).toEqual({ done: true });
+    const html = frames
+      .filter((frame) => "chunk" in frame)
+      .map((frame) => frame.chunk)
+      .join("");
+    expect(html.startsWith("<html><head>")).toBe(true);
+    expect(html).toContain("<div>/page</div>");
+    expect(html.endsWith("</body></html>")).toBe(true);
+  });
+
+  it("replaces the head marker with the head callback output", async () => {
+    const handle = makeHandler({
+      streamCallbacks: {
+        node: () => createElement("p", null, "body"),
+        head: async () => "<title>streamed</title>",
+      },
+    });
+
+    const frames = await collectFrames(handle, {
+      url: "/",
+      template: TEMPLATE,
+    });
+
+    expect(frames[0].chunk).toBe("<html><head><title>streamed</title></head><body>");
+  });
+
+  it("falls back to context.app when no node callback is given", async () => {
+    const handle = makeHandler({
+      setup: () => ({ app: createElement("span", null, "from app") }),
+      streamCallbacks: {},
+    });
+
+    const frames = await collectFrames(handle, {
+      url: "/",
+      template: TEMPLATE,
+    });
+
+    const html = frames.map((frame) => frame.chunk ?? "").join("");
+    expect(html).toContain("<span>from app</span>");
+  });
+
+  it("emits a single error frame when the template lacks the body marker", async () => {
+    const onError = vi.fn();
+    const handle = makeHandler({ error: onError });
+
+    const frames = await collectFrames(handle, {
+      url: "/",
+      template: "<html></html>",
+    });
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].error).toMatch(/SSR_BODY/);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it("emits a single error frame when the shell throws", async () => {
+    const Boom = () => {
+      throw new Error("shell boom");
+    };
+    const handle = makeHandler({
+      streamCallbacks: { node: () => createElement(Boom) },
+    });
+
+    const frames = await collectFrames(handle, {
+      url: "/",
+      template: TEMPLATE,
+    });
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].error).toBe("shell boom");
+  });
+
+  it("emits an error frame when url is missing", async () => {
+    const frames = await collectFrames(makeHandler(), {
+      template: TEMPLATE,
+    });
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].error).toMatch(/URL is required/);
+  });
+
+  it("runs cleanup after streaming completes", async () => {
+    const cleanup = vi.fn();
+    const handle = makeHandler({ cleanup });
+
+    await collectFrames(handle, { url: "/", template: TEMPLATE });
+
+    expect(cleanup).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "/" }),
+    );
   });
 });

--- a/universal-renderer/src/stdio/index.ts
+++ b/universal-renderer/src/stdio/index.ts
@@ -1,4 +1,8 @@
-import type { SSRHandlerOptions } from "../types";
+import { PassThrough } from "node:stream";
+
+import type { ReactNode } from "react";
+import { SSR_MARKERS } from "../constants";
+import type { SSRHandlerOptions, StreamHandlerOptions } from "../types";
 
 /**
  * Options for the stdio renderer which communicates over stdin/stdout.
@@ -10,6 +14,24 @@ export type StdioOptions<
    * Optional error handler invoked when JSON parsing, rendering, or cleanup fails.
    */
   error?: (err: Error) => void | Promise<void>;
+
+  /**
+   * Optional streaming callbacks for React 18+ streaming SSR.
+   * When provided, requests that include a `template` are answered with a
+   * sequence of `{ chunk }` frames terminated by `{ done: true }` instead of
+   * a single response line.
+   */
+  streamCallbacks?: StreamHandlerOptions<TContext>["streamCallbacks"];
+};
+
+/**
+ * A parsed stdio request. Requests carrying a `template` are streaming
+ * requests; all others are static renders.
+ */
+type StdioRequest = {
+  url?: string;
+  props?: Record<string, any>;
+  template?: string;
 };
 
 /**
@@ -84,12 +106,144 @@ export function createLineHandler<
 }
 
 /**
+ * Builds the streaming request handler used by {@link createRenderer}.
+ *
+ * Takes a parsed streaming request (`{ url, props?, template }`) and a `write`
+ * function for emitting single-line JSON frames. The template's body marker is
+ * split into head/tail; the head (with the head marker replaced) is emitted
+ * first, React chunks follow as they render, then the tail and a terminal
+ * `{ done: true }` frame. Failures emit a terminal `{ error }` frame instead,
+ * so the Ruby adapter always receives exactly one terminal frame and the
+ * protocol stream stays synchronized.
+ *
+ * Exported for testing; production code should use {@link createRenderer}.
+ */
+export function createStreamLineHandler<
+  TContext extends Record<string, any> = Record<string, any>,
+>(options: StdioOptions<TContext>) {
+  const { setup, cleanup, streamCallbacks, error: onError } = options;
+
+  if (!setup) throw new Error("setup callback is required");
+  if (!streamCallbacks)
+    throw new Error("streamCallbacks are required for streaming");
+
+  return async function handleStreamRequest(
+    payload: StdioRequest,
+    write: (line: string) => void,
+  ): Promise<void> {
+    let context: TContext | undefined;
+
+    try {
+      const { url, props = {}, template = "" } = payload;
+
+      if (!url) throw new Error("URL is required");
+      if (!template.includes(SSR_MARKERS.BODY)) {
+        throw new Error(`Template missing ${SSR_MARKERS.BODY} marker`);
+      }
+
+      context = await setup(url, props);
+
+      let reactNode: ReactNode;
+      if (streamCallbacks.node) {
+        reactNode = streamCallbacks.node(context);
+      } else if ("app" in context) {
+        reactNode = (context as any).app;
+      } else if ("jsx" in context) {
+        reactNode = (context as any).jsx;
+      } else {
+        throw new Error("No app callback provided");
+      }
+
+      // Imported lazily so stdio renderers that never stream don't need
+      // react-dom installed at all.
+      const { renderToPipeableStream } = await import("react-dom/server.node");
+
+      const [head = "", tail = ""] = template.split(SSR_MARKERS.BODY);
+
+      await new Promise<void>((resolve) => {
+        let settled = false;
+
+        const fail = (err: any) => {
+          if (settled) return;
+          settled = true;
+          console.error("[universal-renderer] Stream shell error", err);
+          void onError?.(err);
+          write(JSON.stringify({ error: err?.message ?? String(err) }));
+          resolve();
+        };
+
+        const { pipe } = renderToPipeableStream(reactNode, {
+          async onShellReady() {
+            try {
+              const finalHead = await streamCallbacks.head?.(context!);
+              write(
+                JSON.stringify({
+                  chunk: head.replace(SSR_MARKERS.HEAD, finalHead ?? ""),
+                }),
+              );
+
+              const stream = new PassThrough();
+              const transform = streamCallbacks.transform?.(context!);
+
+              // Watch the end of the pipeline, not the source: with a
+              // transform, the PassThrough can end while the transform still
+              // holds buffered output, and emitting the tail then would
+              // interleave it into the body.
+              const output = transform ? stream.pipe(transform) : stream;
+
+              output.on("data", (chunk: Buffer) => {
+                write(JSON.stringify({ chunk: chunk.toString() }));
+              });
+              output.on("error", fail);
+              output.on("end", () => {
+                if (settled) return;
+                settled = true;
+                write(JSON.stringify({ chunk: tail }));
+                write(JSON.stringify({ done: true }));
+                resolve();
+              });
+
+              pipe(stream);
+            } catch (err) {
+              fail(err);
+            }
+          },
+          onShellError: fail,
+          onError(err: unknown) {
+            // Post-shell errors: React falls back to client rendering for the
+            // failed boundary and the stream still completes normally.
+            console.error("[universal-renderer] Stream error", err);
+            void onError?.(err as Error);
+          },
+        });
+      });
+    } catch (err: any) {
+      console.error("[universal-renderer] Stream render error", err);
+      await onError?.(err);
+      write(JSON.stringify({ error: err?.message ?? String(err) }));
+    } finally {
+      if (context && cleanup) {
+        try {
+          await cleanup(context);
+        } catch (err: any) {
+          console.error("[universal-renderer] Cleanup error", err);
+          await onError?.(err);
+        }
+      }
+    }
+  };
+}
+
+/**
  * Creates a long-lived renderer that reads JSON payloads from stdin, renders the
  * application, and writes a single-line JSON response to stdout.
  *
- * The payload **must** follow the structure `{ url: string, props?: object }`.
- * The response follows `RenderOutput` – `{ head?: string, body: string, body_attrs?: object }`,
- * plus an `error` string when rendering fails.
+ * The payload **must** follow the structure `{ url: string, props?: object, template?: string }`.
+ * For static requests the response follows `RenderOutput` –
+ * `{ head?: string, body: string, body_attrs?: object }`, plus an `error`
+ * string when rendering fails. Requests that include a `template` (and when
+ * `streamCallbacks` are configured) are answered with a sequence of
+ * `{ chunk: string }` frames terminated by `{ done: true }` or `{ error }`.
  *
  * This helper is intended to interoperate with the Ruby stdio adapter, which
  * maintains a small pool of processes and communicates via stdin/stdout.
@@ -98,6 +252,34 @@ export async function createRenderer<
   TContext extends Record<string, any> = Record<string, any>,
 >(options: StdioOptions<TContext>): Promise<void> {
   const handleLine = createLineHandler(options);
+  const handleStreamRequest = options.streamCallbacks
+    ? createStreamLineHandler(options)
+    : undefined;
+
+  const writeLine = (line: string) => process.stdout.write(line + "\n");
+
+  // Streaming requests are detected by the presence of a `template`, which
+  // requires a parse. Static requests then re-parse inside handleLine — an
+  // acceptable cost to keep createLineHandler's public line-in/line-out
+  // contract intact.
+  async function dispatch(line: string): Promise<void> {
+    if (handleStreamRequest) {
+      let payload: StdioRequest | undefined;
+      try {
+        payload = JSON.parse(line);
+      } catch {
+        // Malformed JSON falls through to handleLine, which owns the
+        // in-band error response for unparseable lines.
+      }
+      if (payload && typeof payload.template === "string") {
+        await handleStreamRequest(payload, writeLine);
+        return;
+      }
+    }
+
+    const response = await handleLine(line);
+    if (response !== undefined) writeLine(response);
+  }
 
   // stdout is the protocol channel: one response line per request line.
   // App code (or its dependencies) calling console.log would inject frames
@@ -117,14 +299,12 @@ export async function createRenderer<
     while ((index = buffer.indexOf("\n")) !== -1) {
       const line = buffer.slice(0, index);
       buffer = buffer.slice(index + 1);
-      const response = await handleLine(line);
-      if (response !== undefined) process.stdout.write(response + "\n");
+      await dispatch(line);
     }
   }
 
   buffer += decoder.decode();
   if (buffer.length > 0) {
-    const response = await handleLine(buffer);
-    if (response !== undefined) process.stdout.write(response + "\n");
+    await dispatch(buffer);
   }
 }


### PR DESCRIPTION
## Summary

Implement React 18+ streaming rendering via the stdio adapter, enabling low-latency server-side rendering without an external SSR server. The stdio pipe protocol now extends to support streaming requests alongside static renders.

## What's New

**Streaming requests** (carrying a `template` key) receive a sequence of newline-delimited JSON frames:
- `{"chunk": "..."}` for each piece of rendered HTML (from React's pipeable stream)
- `{"done": true}` on completion (or `{"error": "..."}` on failure)

The protocol stays **synchronized** even on render failures — error frames are in-band and terminal, so the child process survives and can handle subsequent requests.

## Changes

### Node side (`universal-renderer/src/stdio`)
- New `createStreamLineHandler` dispatches template requests to `renderToPipeableStream` (mirrors HTTP stream handler)
- `dispatch` function in `createRenderer` detects streaming via the `template` key
- `streamCallbacks` (node/head/transform) are optional; non-streaming renderers skip importing `react-dom`
- **8 new unit tests** covering streaming, head replacement, error frames, cleanup, and error recovery

### Ruby side (`lib/universal_renderer/adapter/stdio`)
- `Stdio#stream` relays chunks into `response.stream.write`
- `Stdio#supports_streaming?` now returns true (was hardcoded false)
- New `StdioProcess#render_stream` reads frames under a **per-frame** idle timeout (not a single round-trip)
  - Raises `RenderError` for in-band failures (process survives)
  - Closes and respawns on timeout/desync errors
- Persistent `@read_buffer` fixes latent bug where multiple frames arriving in one pipe read would drop trailing bytes
- Two error classes: `RenderError` (protocol-synchronized) and `ProtocolError` (stream desync)
- **Graceful fallback**: stream failures before any chunk is written return false (buffered fallback); after bytes are out, closes stream (avoids double-render)
- **4 unit tests** and **6 integration tests** (interleave static/streaming, test error recovery)

### Documentation & Demo
- README and `universal-renderer/README.md` updated to note both engines support streaming
- Demo app's stdio renderer now includes `streamCallbacks` with the same `head`/`transform` as HTTP server
- `Procfile.dev` commented out (optional; user had toggled this)
- `HomeController#enable_ssr` set to `streaming: true` to demonstrate the feature

### Verification
✅ **93 Ruby tests pass** (all specs green, including new streaming coverage)  
✅ **22 Node tests pass** (8 new, all streaming handler tests)  
✅ **Linting clean** (RuboCop, TypeScript, tsdown build succeeds)  
✅ **End-to-end tested**: Demo app with `SSR_ENGINE=stdio enable_ssr streaming: true` (no HTTP SSR server) returns `transfer-encoding: chunked` with fully server-rendered React

## Test Plan

1. ✅ Run full Ruby suite: `bundle exec rspec` → 93 examples, 0 failures
2. ✅ Run Node suite: `cd universal-renderer && bun run test` → 22 tests pass
3. ✅ Linting: `bundle exec rubocop`, `tsc --noEmit` → clean
4. ✅ Build: `cd universal-renderer && bun run build` → succeeds
5. ✅ Live test: `SSR_ENGINE=stdio bundle exec rails server` + `curl -H 'Accept: text/html'` → streamed response with React-rendered content