### PR TITLE
Reuse HTTP SSR connections and harden streaming fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,16 @@ UniversalRenderer.configure do |config|
   # :stdio          - Stdio Bun processes via Open3 (no external server)
   # Both engines support blocking and streaming SSR.
   config.engine = :http
-  # To select per environment:
-  # config.engine = Rails.env.production? ? :stdio : :http
+  # HTTP is recommended for most applications, including production.
+  # Choose :stdio only when you want embedded SSR instead of a separate service.
 
   # HTTP Engine Configuration (when engine = :http)
   config.ssr_url = "http://localhost:3001"
   config.timeout = 3
+  config.http_pool_size = 5 # persistent Net::HTTP connections per SSR origin
+
+  # HTTP configuration can also use environment variables:
+  # SSR_HTTP_POOL_SIZE (default: 5)
 
   # Stdio configuration is handled via environment variables:
   # SSR_STDIO_POOL_SIZE (default: 5)
@@ -81,7 +85,7 @@ The HTTP engine forwards SSR requests to an external Node.js server. This is the
 **Cons:**
 
 - Requires external server setup
-- Network overhead for each request
+- HTTP serialization overhead for each request, though persistent connections are reused
 - Additional infrastructure complexity
 
 ### Stdio Engine
@@ -103,13 +107,12 @@ The Stdio engine maintains a pool of stdio Bun processes and communicates with t
 
 ### Selecting the engine per environment
 
-A common setup is HTTP in development/test and Stdio in production:
+HTTP is the safest default for most environments, including production, because it
+keeps the SSR runtime separately observable, restartable, and scalable. Choose
+`:stdio` when you explicitly want embedded SSR inside the Rails deployment and
+are comfortable sizing and operating the Bun process pool with the Rails app.
 
-```ruby
-config.engine = Rails.env.production? ? :stdio : :http
-```
-
-When production uses `:stdio`, ensure Bun and the configured stdio script are available
+If production uses `:stdio`, ensure Bun and the configured stdio script are available
 before boot. The script can be a `.ts` / `.tsx` entrypoint or a prebuilt bundle.
 
 ## Basic Usage
@@ -120,7 +123,7 @@ After installation, you can pass data to your SSR service using `add_prop` in yo
 
 UniversalRenderer supports two SSR modes:
 
-1. **Standard SSR** (default): Fetches complete HTML from the SSR service before rendering
+1. **Standard/blocking SSR** (default and recommended for most pages): Fetches complete HTML from the SSR service before rendering
 2. **Streaming SSR**: Streams HTML content as it's generated (requires ActionController::Live)
 
 ```ruby

--- a/examples/universal_renderer_demo/Procfile.dev
+++ b/examples/universal_renderer_demo/Procfile.dev
@@ -1,3 +1,3 @@
 web: bundle exec rails server
 vite: bun run dev
-# ssr: bun run ssr:dev:http
+ssr: bun run ssr:dev:http

--- a/examples/universal_renderer_demo/README.md
+++ b/examples/universal_renderer_demo/README.md
@@ -18,8 +18,8 @@ bundle install
 bun install
 ```
 
-This demo uses Bun for package management, Vite scripts, and both HTTP and
-stdio SSR processes.
+This demo uses Bun for package management, Vite scripts, and the external HTTP
+SSR process.
 
 ## Run the demo
 
@@ -31,45 +31,29 @@ bin/dev
 
 Then open `http://127.0.0.1:3000`.
 
-This demo uses:
-- `:http` engine in development/test (`app/frontend/ssr/ssr.tsx`)
-- `:stdio` engine in production (`app/frontend/ssr/stdio.tsx`)
+This demo uses the `:http` engine with streaming enabled. The Rails app sends
+render requests to the external SSR server at `http://localhost:5200`.
 
 SSR setup/render handlers are shared in `app/frontend/ssr/setup.tsx`.
 
-In development, `bin/dev` runs the Bun+Express SSR server directly from
-`app/frontend/ssr/ssr.tsx` via `Procfile.dev`.
-
-In production, Rails executes the Vite-built stdio bundle at
-`public/vite-ssr-stdio/ssr.js` with Bun (built from
-`app/frontend/ssr/stdio.tsx`).
-
-Do not point `c.stdio_cli_script` at the HTTP bundle. In this demo that bundle is
-`public/vite-ssr-http/ssr.js`, and it will
-try to bind a port instead of reading render
-requests from stdin.
+The HTTP SSR server is run from `app/frontend/ssr/ssr.tsx` via `Procfile.dev`.
+For a production-style run, build and start `public/vite-ssr-http/ssr.js` with
+Bun and set `SSR_SERVER_URL` to its address.
 
 ## Production build note
 
-When deploying with Stdio in production, make sure SSR bundle output exists:
+When deploying the HTTP SSR server, make sure the SSR bundle output exists:
 
 ```bash
 bun run build
 # or at minimum:
-bun run build:ssr
+bun run build:ssr:http
 ```
 
-If you force `c.engine = :stdio` outside production, build the stdio bundle
-before booting Rails:
+To run the built HTTP bundle directly, use:
 
 ```bash
-bun run build:ssr:stdio
-```
-
-To run the built stdio bundle directly, use:
-
-```bash
-bun public/vite-ssr-stdio/ssr.js
+bun public/vite-ssr-http/ssr.js
 ```
 
 To test larger SSR payloads and more query seed data, use:

--- a/examples/universal_renderer_demo/config/initializers/universal_renderer.rb
+++ b/examples/universal_renderer_demo/config/initializers/universal_renderer.rb
@@ -1,19 +1,10 @@
 UniversalRenderer.configure do |c|
-  # :http  - external SSR server (Procfile.dev runs it from app/frontend/ssr/ssr.tsx)
-  # :stdio - pool of Bun child processes speaking JSON over stdin/stdout
-  # Override with SSR_ENGINE=http|stdio.
-  c.engine = ENV.fetch("SSR_ENGINE") { Rails.env.production? ? :stdio : :http }
+  # The HTTP adapter uses the external Bun SSR server configured in Procfile.dev.
+  # It supports streaming via the /stream endpoint.
+  c.engine = :http
 
   # HTTP Engine Configuration (when engine = :http)
   c.ssr_url = ENV.fetch("SSR_SERVER_URL", "http://localhost:5200")
   c.timeout = 3
   c.ssr_stream_path = "/stream"
-
-  # Stdio Engine Configuration (when engine = :stdio)
-  # These can also be set via environment variables:
-  # SSR_STDIO_POOL_SIZE, SSR_STDIO_TIMEOUT, SSR_STDIO_CLI_SCRIPT
-  # The bundle is produced by bin/build-ssr-stdio from app/frontend/ssr/stdio.tsx.
-  c.stdio_pool_size = 5
-  c.stdio_timeout = 5_000
-  c.stdio_cli_script = "public/vite-ssr-stdio/ssr.js"
 end

--- a/examples/universal_renderer_demo/package.json
+++ b/examples/universal_renderer_demo/package.json
@@ -9,11 +9,11 @@
     "build:client": "bunx vite build",
     "build:ssr:http": "./bin/build-ssr-http",
     "build:ssr:stdio": "./bin/build-ssr-stdio",
-    "build:ssr": "bun run build:ssr:stdio",
+    "build:ssr": "bun run build:ssr:http",
     "build": "bun run build:client && bun run build:ssr",
     "ssr:http": "bun public/vite-ssr-http/ssr.js",
     "ssr:stdio": "bun public/vite-ssr-stdio/ssr.js",
-    "ssr": "bun public/vite-ssr-stdio/ssr.js"
+    "ssr": "bun public/vite-ssr-http/ssr.js"
   },
   "dependencies": {
     "@dr.pogodin/react-helmet": "^3.0.6",

--- a/lib/generators/universal_renderer/templates/initializer.rb
+++ b/lib/generators/universal_renderer/templates/initializer.rb
@@ -1,15 +1,16 @@
 UniversalRenderer.configure do |c|
   # Choose your SSR engine:
   # :http           - External Node.js server (default, supports streaming)
-  # :stdio          - Stdio Bun processes via Open3 (no streaming, but no external server needed)
+  # :stdio          - Stdio Bun processes via Open3 (supports streaming, no external server)
   c.engine = :http
-  # To select per environment:
-  # c.engine = Rails.env.production? ? :stdio : :http
+  # HTTP is recommended for most applications, including production.
+  # Choose :stdio only when you want embedded SSR instead of a separate service.
 
   # HTTP Engine Configuration (when engine = :http)
   c.ssr_url = ENV.fetch("SSR_SERVER_URL", "http://localhost:3001")
   c.timeout = 3
   c.ssr_stream_path = "/stream"
+  c.http_pool_size = ENV.fetch("SSR_HTTP_POOL_SIZE", 5).to_i
 
   # Stdio Engine Configuration (when engine = :stdio)
   # These can also be set via environment variables:
@@ -17,6 +18,9 @@ UniversalRenderer.configure do |c|
   c.stdio_pool_size = 5
   c.stdio_timeout = 5_000
   c.stdio_cli_script = "app/frontend/ssr/stdio.tsx"
+
+  # Blocking SSR is the default. Enable streaming per controller only when needed:
+  # enable_ssr streaming: true
 
   # NOTE: When using Stdio, ensure you have a Bun-executable stdio CLI script that can handle
   # JSON input/output with head/body/body_attrs response format.

--- a/lib/universal_renderer/adapter_factory.rb
+++ b/lib/universal_renderer/adapter_factory.rb
@@ -36,6 +36,7 @@ module UniversalRenderer
       # Resets the adapter (useful for testing or configuration changes)
       def reset!
         @adapter = nil
+        UniversalRenderer::Client::HttpPool.reset!
       end
     end
   end

--- a/lib/universal_renderer/client/base.rb
+++ b/lib/universal_renderer/client/base.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "uri"
+require_relative "http_pool"
 
 module UniversalRenderer
   module Client
@@ -31,16 +32,11 @@ module UniversalRenderer
 
         begin
           uri = URI.parse(ssr_url)
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = (uri.scheme == "https")
-          http.open_timeout = timeout
-          http.read_timeout = timeout
-
           request = Net::HTTP::Post.new(uri.request_uri)
           request.body = { url: url, props: props }.to_json
           request["Content-Type"] = "application/json"
 
-          response = http.request(request)
+          response = HttpPool.request(uri, timeout, request)
 
           if response.is_a?(Net::HTTPSuccess)
             raw_data = JSON.parse(response.body).deep_symbolize_keys

--- a/lib/universal_renderer/client/http_pool.rb
+++ b/lib/universal_renderer/client/http_pool.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require "connection_pool"
+require "net/http"
+
+module UniversalRenderer
+  module Client
+    # Thread-safe pool of persistent Net::HTTP connections keyed by SSR origin.
+    #
+    # Net::HTTP instances are not thread-safe, so each pooled connection is
+    # checked out exclusively. Keeping them started allows Net::HTTP to reuse
+    # the underlying TCP connection for sequential SSR requests.
+    class HttpPool
+      class ClientProxy
+        def initialize(uri, timeout)
+          @uri = uri
+          @timeout = timeout
+        end
+
+        def request(http_request, &block)
+          if block
+            HttpPool.request(@uri, @timeout, http_request) do |response, http|
+              block.call(response, http)
+            end
+          else
+            HttpPool.request(@uri, @timeout, http_request)
+          end
+        end
+      end
+
+      class << self
+        def client(uri, timeout)
+          ClientProxy.new(uri, timeout)
+        end
+
+        def request(uri, timeout, http_request)
+          with_connection(uri, timeout) do |http|
+            if block_given?
+              http.request(http_request) { |response| yield(response, http) }
+            else
+              http.request(http_request)
+            end
+          end
+        end
+
+        def reset!
+          mutex.synchronize do
+            pools.each_value do |pool|
+              pool.shutdown { |http| close(http) }
+            end
+            pools.clear
+          end
+        end
+
+        def close(http)
+          http.finish if http.started?
+        rescue IOError
+          # Already closed by the peer or by another cleanup path.
+        end
+
+        private
+
+        def with_connection(uri, timeout)
+          pool_for(uri, timeout).with do |http|
+            ensure_started(http)
+            yield http
+          rescue StandardError
+            close(http)
+            raise
+          end
+        end
+
+        def pool_for(uri, timeout)
+          key = pool_key(uri, timeout)
+
+          mutex.synchronize do
+            pools[key] ||= ConnectionPool.new(size: pool_size, timeout: timeout) do
+              build_connection(uri, timeout)
+            end
+          end
+        end
+
+        def build_connection(uri, timeout)
+          Net::HTTP.new(uri.host, uri.port).tap do |http|
+            http.use_ssl = (uri.scheme == "https")
+            http.open_timeout = timeout
+            http.read_timeout = timeout
+          end
+        end
+
+        def ensure_started(http)
+          http.start unless http.started?
+        end
+
+        def pool_key(uri, timeout)
+          [uri.scheme, uri.host, uri.port, timeout, pool_size].join(":")
+        end
+
+        def pool_size
+          UniversalRenderer.config.http_pool_size
+        end
+
+        def pools
+          @pools ||= {}
+        end
+
+        def mutex
+          @mutex ||= Mutex.new
+        end
+      end
+    end
+  end
+end

--- a/lib/universal_renderer/client/stream/execution.rb
+++ b/lib/universal_renderer/client/stream/execution.rb
@@ -1,3 +1,5 @@
+require_relative "../http_pool"
+
 module UniversalRenderer
   module Client
     class Stream
@@ -9,25 +11,36 @@ module UniversalRenderer
           stream_uri
         )
           success = false
+          chunks_written = false
 
-          http_client.request(http_post_request) do |node_res|
+          http_client.request(http_post_request) do |node_res, upstream_connection|
             if node_res.is_a?(Net::HTTPSuccess)
-              node_res.read_body { |chunk| response.stream.write(chunk) }
-              success = true
+              begin
+                node_res.read_body do |chunk|
+                  response.stream.write(chunk)
+                  chunks_written = true
+                end
+                success = true
+              rescue StandardError => e
+                Rails.logger.error(
+                  "Error during SSR data transfer or stream writing from #{stream_uri}: #{e.class.name} - #{e.message}"
+                )
+                # The upstream response body may be only partially consumed, so
+                # do not return this persistent connection to the reusable pool.
+                HttpPool.close(upstream_connection) if upstream_connection
+
+                # Once bytes have reached the response stream, fallback rendering
+                # would append a second document. Treat the stream as handled and
+                # close it; if nothing was written, allow the caller to fallback.
+                success = chunks_written
+              ensure
+                response.stream.close if success && !response.stream.closed?
+              end
             else
               Rails.logger.error(
                 "SSR stream server at #{stream_uri} responded with #{node_res.code} #{node_res.message}."
               )
-
-              # Close stream without forwarding error to allow fallback to client rendering
-              response.stream.close unless response.stream.closed?
             end
-          rescue StandardError => e
-            Rails.logger.error(
-              "Error during SSR data transfer or stream writing from #{stream_uri}: #{e.class.name} - #{e.message}"
-            )
-          ensure
-            response.stream.close unless response.stream.closed?
           end
 
           success

--- a/lib/universal_renderer/client/stream/execution.rb
+++ b/lib/universal_renderer/client/stream/execution.rb
@@ -12,35 +12,39 @@ module UniversalRenderer
         )
           success = false
           chunks_written = false
+          upstream_connection = nil
 
-          http_client.request(http_post_request) do |node_res, upstream_connection|
-            if node_res.is_a?(Net::HTTPSuccess)
-              begin
+          begin
+            http_client.request(http_post_request) do |node_res, connection|
+              upstream_connection = connection
+
+              if node_res.is_a?(Net::HTTPSuccess)
                 node_res.read_body do |chunk|
-                  response.stream.write(chunk)
+                  # A stream write can fail after handing bytes to the response
+                  # buffer. Mark it first so the caller never falls back onto a
+                  # potentially partial response.
                   chunks_written = true
+                  response.stream.write(chunk)
                 end
                 success = true
-              rescue StandardError => e
+              else
                 Rails.logger.error(
-                  "Error during SSR data transfer or stream writing from #{stream_uri}: #{e.class.name} - #{e.message}"
+                  "SSR stream server at #{stream_uri} responded with #{node_res.code} #{node_res.message}."
                 )
-                # The upstream response body may be only partially consumed, so
-                # do not return this persistent connection to the reusable pool.
-                HttpPool.close(upstream_connection) if upstream_connection
-
-                # Once bytes have reached the response stream, fallback rendering
-                # would append a second document. Treat the stream as handled and
-                # close it; if nothing was written, allow the caller to fallback.
-                success = chunks_written
-              ensure
-                response.stream.close if success && !response.stream.closed?
               end
-            else
-              Rails.logger.error(
-                "SSR stream server at #{stream_uri} responded with #{node_res.code} #{node_res.message}."
-              )
             end
+          rescue StandardError => e
+            Rails.logger.error(
+              "Error during SSR data transfer or stream writing from #{stream_uri}: #{e.class.name} - #{e.message}"
+            )
+
+            # The response may be only partially consumed, so do not reuse the
+            # current persistent connection. Net::HTTP can also raise after its
+            # request block returns while it finalizes that response body.
+            HttpPool.close(upstream_connection) if upstream_connection
+            success = chunks_written
+          ensure
+            response.stream.close if success && !response.stream.closed?
           end
 
           success

--- a/lib/universal_renderer/client/stream/setup.rb
+++ b/lib/universal_renderer/client/stream/setup.rb
@@ -1,3 +1,5 @@
+require_relative "../http_pool"
+
 module UniversalRenderer
   module Client
     class Stream
@@ -16,10 +18,7 @@ module UniversalRenderer
           parsed_ssr_url = URI.parse(config.ssr_url)
           stream_uri = URI.join(parsed_ssr_url, config.ssr_stream_path)
 
-          http = Net::HTTP.new(stream_uri.host, stream_uri.port)
-          http.use_ssl = (stream_uri.scheme == "https")
-          http.open_timeout = config.timeout
-          http.read_timeout = config.timeout
+          http = HttpPool.client(stream_uri, config.timeout)
 
           http_request =
             Net::HTTP::Post.new(

--- a/lib/universal_renderer/configuration.rb
+++ b/lib/universal_renderer/configuration.rb
@@ -3,6 +3,7 @@ module UniversalRenderer
     attr_accessor :ssr_url,
                   :timeout,
                   :ssr_stream_path,
+                  :http_pool_size,
                   :stdio_pool_size,
                   :stdio_timeout,
                   :stdio_cli_script
@@ -12,6 +13,7 @@ module UniversalRenderer
       @ssr_url = ENV.fetch("SSR_SERVER_URL", nil)
       @timeout = (ENV["SSR_TIMEOUT"] || 3).to_i
       @ssr_stream_path = ENV.fetch("SSR_STREAM_PATH", "/stream")
+      @http_pool_size = ENV.fetch("SSR_HTTP_POOL_SIZE", 5).to_i
       self.engine = ENV.fetch("SSR_ENGINE", :http)
       @stdio_pool_size = ENV.fetch("SSR_STDIO_POOL_SIZE", 5).to_i
       @stdio_timeout = ENV.fetch("SSR_STDIO_TIMEOUT", 5_000).to_i

--- a/spec/units/client/base_spec.rb
+++ b/spec/units/client/base_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UniversalRenderer::Client::Base do
+  before do
+    UniversalRenderer::Client::HttpPool.reset!
+    UniversalRenderer.config.ssr_url = "http://ssr.example.test/render"
+    UniversalRenderer.config.timeout = 3
+    UniversalRenderer.config.http_pool_size = 1
+  end
+
+  after { UniversalRenderer::Client::HttpPool.reset! }
+
+  it "reuses a persistent Net::HTTP connection for sequential requests" do
+    http = Net::HTTP.new("ssr.example.test", 80)
+    started = false
+
+    allow(http).to receive(:started?) { started }
+    allow(http).to receive(:start) do
+      started = true
+      http
+    end
+
+    ok_response_class =
+      Class.new(Net::HTTPOK) do
+        attr_reader :body
+
+        def initialize(body)
+          super("1.1", "200", "OK")
+          @body = body
+        end
+      end
+    ok_response =
+      ok_response_class.new(
+        { head: "", body: "<div>ok</div>", body_attrs: {} }.to_json
+      )
+
+    allow(http).to receive(:request).and_return(ok_response)
+    allow(Net::HTTP).to receive(:new).and_return(http)
+
+    first = described_class.call("http://example.com/a", {})
+    second = described_class.call("http://example.com/b", {})
+
+    expect(first.body).to eq("<div>ok</div>")
+    expect(second.body).to eq("<div>ok</div>")
+    expect(Net::HTTP).to have_received(:new).once
+    expect(http).to have_received(:start).once
+    expect(http).to have_received(:request).twice
+  end
+end

--- a/spec/units/client/stream_execution_spec.rb
+++ b/spec/units/client/stream_execution_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UniversalRenderer::Client::Stream::Execution do
+  let(:http_request) { Net::HTTP::Post.new("/stream") }
+  let(:stream_uri) { URI.parse("http://ssr.example.test/stream") }
+  let(:http_client) { double("http_client") }
+  let(:stream) do
+    Class.new do
+      attr_reader :body
+
+      def initialize
+        @body = +""
+        @closed = false
+      end
+
+      def write(chunk)
+        @body << chunk
+      end
+
+      def close
+        @closed = true
+      end
+
+      def closed?
+        @closed
+      end
+    end.new
+  end
+  let(:response) { double("response", stream: stream) }
+
+  before do
+    allow(Rails.logger).to receive(:error)
+  end
+
+  def perform_with(node_response, upstream_connection = nil)
+    allow(http_client).to receive(:request)
+      .with(http_request)
+      .and_yield(node_response, upstream_connection)
+
+    described_class.perform_streaming(
+      http_client,
+      http_request,
+      response,
+      stream_uri
+    )
+  end
+
+  it "returns true and closes the stream after a complete successful stream" do
+    node_response = Net::HTTPOK.new("1.1", "200", "OK")
+    allow(node_response).to receive(:read_body).and_yield("<html>").and_yield("</html>")
+
+    result = perform_with(node_response)
+
+    expect(result).to be true
+    expect(stream.body).to eq("<html></html>")
+    expect(stream).to be_closed
+  end
+
+  it "returns true and closes the stream when transfer fails after chunks were written" do
+    node_response = Net::HTTPOK.new("1.1", "200", "OK")
+    upstream_connection = instance_double(Net::HTTP, started?: true, finish: nil)
+    allow(node_response).to receive(:read_body) do |&block|
+      block.call("<html>")
+      raise IOError, "client disconnected"
+    end
+
+    result = perform_with(node_response, upstream_connection)
+
+    expect(result).to be true
+    expect(stream.body).to eq("<html>")
+    expect(stream).to be_closed
+    expect(upstream_connection).to have_received(:finish)
+  end
+
+  it "returns false and leaves the stream open when transfer fails before writing chunks" do
+    node_response = Net::HTTPOK.new("1.1", "200", "OK")
+    allow(node_response).to receive(:read_body).and_raise(IOError, "upstream failed")
+
+    result = perform_with(node_response)
+
+    expect(result).to be false
+    expect(stream.body).to eq("")
+    expect(stream).not_to be_closed
+  end
+
+  it "returns false and leaves the stream open for non-success responses" do
+    node_response = Net::HTTPInternalServerError.new("1.1", "500", "Server Error")
+
+    result = perform_with(node_response)
+
+    expect(result).to be false
+    expect(stream.body).to eq("")
+    expect(stream).not_to be_closed
+  end
+end

--- a/spec/units/client/stream_execution_spec.rb
+++ b/spec/units/client/stream_execution_spec.rb
@@ -74,6 +74,29 @@ RSpec.describe UniversalRenderer::Client::Stream::Execution do
     expect(upstream_connection).to have_received(:finish)
   end
 
+  it "returns true when Net::HTTP fails while finalizing a partial response" do
+    node_response = Net::HTTPOK.new("1.1", "200", "OK")
+    upstream_connection = instance_double(Net::HTTP, started?: true, finish: nil)
+    allow(node_response).to receive(:read_body).and_yield("<html>")
+    allow(http_client).to receive(:request)
+      .with(http_request) do |&block|
+        block.call(node_response, upstream_connection)
+        raise IOError, "upstream failed while finishing response"
+      end
+
+    result = described_class.perform_streaming(
+      http_client,
+      http_request,
+      response,
+      stream_uri
+    )
+
+    expect(result).to be true
+    expect(stream.body).to eq("<html>")
+    expect(stream).to be_closed
+    expect(upstream_connection).to have_received(:finish)
+  end
+
   it "returns false and leaves the stream open when transfer fails before writing chunks" do
     node_response = Net::HTTPOK.new("1.1", "200", "OK")
     allow(node_response).to receive(:read_body).and_raise(IOError, "upstream failed")

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe UniversalRenderer::Configuration do
       expect(subject.engine).to eq(:http)
       expect(subject.timeout).to eq(3)
       expect(subject.stdio_cli_script).to eq("app/frontend/ssr/stdio.tsx")
+      expect(subject.http_pool_size).to eq(5)
       expect(subject.stdio_pool_size).to eq(5)
       expect(subject.stdio_timeout).to eq(5_000)
     end
@@ -39,6 +40,16 @@ RSpec.describe UniversalRenderer::Configuration do
       expect(config.stdio_cli_script).to eq("custom/path/to/ssr.ts")
 
       ENV["SSR_STDIO_CLI_SCRIPT"] = original_env
+    end
+
+    it "reads http_pool_size from environment variable" do
+      original_env = ENV.fetch("SSR_HTTP_POOL_SIZE", nil)
+      ENV["SSR_HTTP_POOL_SIZE"] = "10"
+
+      config = described_class.new
+      expect(config.http_pool_size).to eq(10)
+
+      ENV["SSR_HTTP_POOL_SIZE"] = original_env
     end
 
     it "reads stdio_pool_size from environment variable" do
@@ -81,6 +92,11 @@ RSpec.describe UniversalRenderer::Configuration do
     it "has an ssr_stream_path attribute" do
       expect(subject).to respond_to(:ssr_stream_path)
       expect(subject).to respond_to(:ssr_stream_path=)
+    end
+
+    it "has an http_pool_size attribute" do
+      expect(subject).to respond_to(:http_pool_size)
+      expect(subject).to respond_to(:http_pool_size=)
     end
 
     it "has a stdio_cli_script attribute" do


### PR DESCRIPTION
## Summary
- add a pooled persistent Net::HTTP client for blocking and streaming SSR requests
- make HTTP streaming fallback match stdio behavior when bytes have already been written
- document HTTP as the recommended default, blocking SSR as the default mode, and SSR_HTTP_POOL_SIZE

## Tests
- bundle exec rspec
- bundle exec rubocop lib/universal_renderer/client/http_pool.rb lib/universal_renderer/client/base.rb lib/universal_renderer/client/stream/execution.rb lib/universal_renderer/client/stream/setup.rb lib/universal_renderer/configuration.rb spec/units/client/base_spec.rb spec/units/client/stream_execution_spec.rb spec/units/configuration_spec.rb