### PR TITLE
Use a configurable, tagged logger instead of hardcoded Rails.logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ UniversalRenderer.configure do |config|
 end
 ```
 
+## Logging
+
+The gem logs through `UniversalRenderer.logger`, which defaults to the host
+application's `Rails.logger` wrapped in `ActiveSupport::TaggedLogging`. Every
+log line is automatically prefixed with `[UniversalRenderer]`, so you can
+distinguish the gem's output in a shared log stream without remembering a
+per-call prefix.
+
+You can replace the logger with any object responding to the standard
+`Logger` interface (useful for routing gem logs to a separate file, a
+different formatter, or a semantic-logging backend):
+
+```ruby
+UniversalRenderer.logger = Logger.new("log/universal_renderer.log")
+```
+
+Setting it back to `nil` restores the default tagged `Rails.logger`.
+```
+
 ## SSR Engines
 
 UniversalRenderer supports two SSR engine modes:

--- a/lib/universal_renderer.rb
+++ b/lib/universal_renderer.rb
@@ -24,5 +24,39 @@ module UniversalRenderer
     def configure
       yield(config)
     end
+
+    # Configurable logger for the gem. Defaults to the host application's
+    # Rails.logger (when Rails is loaded) wrapped in
+    # ActiveSupport::TaggedLogging so every line is prefixed with
+    # [UniversalRenderer]. Host apps can replace it via
+    # UniversalRenderer.logger = MyLogger.new.
+    def logger
+      @logger || default_logger
+    end
+
+    def logger=(logger)
+      @logger =
+        logger.nil? ? nil : ActiveSupport::TaggedLogging.new(logger)
+    end
+
+    # Tags every block of log output with the gem name so host app logs stay
+    # distinguishable without callers having to remember a prefix. Yields the
+    # tagged logger for convenient use:
+    #   UniversalRenderer.log { |log| log.error("...") }
+    def log
+      logger.tagged("UniversalRenderer") { yield logger }
+    end
+
+    private
+
+    def default_logger
+      base =
+        if defined?(Rails) && Rails.respond_to?(:logger) && Rails.logger
+          Rails.logger
+        else
+          ActiveSupport::Logger.new($stdout)
+        end
+      ActiveSupport::TaggedLogging.new(base)
+    end
   end
 end

--- a/lib/universal_renderer/adapter/stdio.rb
+++ b/lib/universal_renderer/adapter/stdio.rb
@@ -21,8 +21,10 @@ module UniversalRenderer
         return nil unless @process_pool
 
         with_process do |process|
-          Rails.logger.debug do
-            "Stdio rendering: #{url} with props keys: #{props.keys}"
+          UniversalRenderer.log do |log|
+            log.debug do
+              "Stdio rendering: #{url} with props keys: #{props.keys}"
+            end
           end
 
           result = process.render(url, props)
@@ -30,9 +32,11 @@ module UniversalRenderer
 
           result = result.deep_symbolize_keys
           if result[:error].present?
-            Rails.logger.error(
-              "Stdio SSR render failed (URL: #{url}): #{result[:error]}"
-            )
+            UniversalRenderer.log do |log|
+              log.error(
+                "Stdio SSR render failed (URL: #{url}): #{result[:error]}"
+              )
+            end
             return nil
           end
 
@@ -43,9 +47,11 @@ module UniversalRenderer
           )
         end
       rescue StandardError => e
-        Rails.logger.error(
-          "Stdio SSR execution failed (URL: #{url}): #{e.full_message}"
-        )
+        UniversalRenderer.log do |log|
+          log.error(
+            "Stdio SSR execution failed (URL: #{url}): #{e.full_message}"
+          )
+        end
         nil
       end
 
@@ -55,8 +61,10 @@ module UniversalRenderer
         chunks_written = false
 
         with_process do |process|
-          Rails.logger.debug do
-            "Stdio streaming: #{url} with props keys: #{props.keys}"
+          UniversalRenderer.log do |log|
+            log.debug do
+              "Stdio streaming: #{url} with props keys: #{props.keys}"
+            end
           end
 
           process.render_stream(url, props, template) do |chunk|
@@ -67,9 +75,11 @@ module UniversalRenderer
 
         true
       rescue StandardError => e
-        Rails.logger.error(
-          "Stdio SSR stream failed (URL: #{url}): #{e.full_message}"
-        )
+        UniversalRenderer.log do |log|
+          log.error(
+            "Stdio SSR stream failed (URL: #{url}): #{e.full_message}"
+          )
+        end
 
         # Once bytes have reached the response stream a fallback render would
         # append a second document to the same response, so close what we have
@@ -90,10 +100,12 @@ module UniversalRenderer
       def setup
         cli_script_path = Rails.root.join(@cli_script)
         unless File.exist?(cli_script_path)
-          Rails.logger.error(
-            "Stdio CLI script not found at #{cli_script_path}. " \
-              "Please ensure the SSR CLI script is available."
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "Stdio CLI script not found at #{cli_script_path}. " \
+                "Please ensure the SSR CLI script is available."
+            )
+          end
           return
         end
 
@@ -106,13 +118,17 @@ module UniversalRenderer
               timeout: timeout_ms / 1000.0
             ) { StdioProcess.new(script, timeout_ms: timeout_ms) }
 
-          Rails.logger.info(
-            "Universal Renderer Stdio process pool (#{@pool_size}) initialized"
-          )
+          UniversalRenderer.log do |log|
+            log.info(
+              "Stdio process pool (#{@pool_size}) initialized"
+            )
+          end
         rescue StandardError => e
-          Rails.logger.error(
-            "Failed to initialize Stdio process pool: #{e.full_message}"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "Failed to initialize Stdio process pool: #{e.full_message}"
+            )
+          end
         end
       end
 
@@ -312,7 +328,9 @@ module UniversalRenderer
           @stderr_thread =
             Thread.new do
               stderr.each_line do |line|
-                Rails.logger.warn("[stdio-ssr] #{line.chomp}")
+                UniversalRenderer.log do |log|
+                  log.warn("stdio-ssr: #{line.chomp}")
+                end
               end
             rescue IOError
               # pipe closed

--- a/lib/universal_renderer/adapter_factory.rb
+++ b/lib/universal_renderer/adapter_factory.rb
@@ -10,9 +10,11 @@ module UniversalRenderer
       # @return [UniversalRenderer::Adapter::Base] The configured adapter
       def create_adapter
         engine = UniversalRenderer.config.engine
-        Rails.logger.info(
-          "UniversalRenderer resolved SSR engine '#{engine}' for Rails env '#{Rails.env}'"
-        )
+        UniversalRenderer.log do |log|
+          log.info(
+            "Resolved SSR engine '#{engine}' for Rails env '#{Rails.env}'"
+          )
+        end
 
         case engine
         when :http
@@ -20,9 +22,11 @@ module UniversalRenderer
         when :stdio
           Adapter::Stdio.new
         else
-          Rails.logger.warn(
-            "Unknown SSR engine '#{engine}'. Falling back to HTTP adapter."
-          )
+          UniversalRenderer.log do |log|
+            log.warn(
+              "Unknown SSR engine '#{engine}'. Falling back to HTTP adapter."
+            )
+          end
           Adapter::Http.new
         end
       end

--- a/lib/universal_renderer/client/base.rb
+++ b/lib/universal_renderer/client/base.rb
@@ -50,20 +50,26 @@ module UniversalRenderer
               body_attrs: raw_data[:body_attrs]
             )
           else
-            Rails.logger.error(
-              "SSR fetch request to #{ssr_url} failed: #{response.code} - #{response.message} (URL: #{url})"
-            )
+            UniversalRenderer.log do |log|
+              log.error(
+                "SSR fetch request to #{ssr_url} failed: #{response.code} - #{response.message} (URL: #{url})"
+              )
+            end
             nil
           end
         rescue Net::OpenTimeout, Net::ReadTimeout => e
-          Rails.logger.error(
-            "SSR fetch request to #{ssr_url} timed out: #{e.class.name} - #{e.message} (URL: #{url})"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "SSR fetch request to #{ssr_url} timed out: #{e.class.name} - #{e.message} (URL: #{url})"
+            )
+          end
           nil
         rescue StandardError => e
-          Rails.logger.error(
-            "SSR fetch request to #{ssr_url} failed: #{e.class.name} - #{e.message} (URL: #{url})"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "SSR fetch request to #{ssr_url} failed: #{e.class.name} - #{e.message} (URL: #{url})"
+            )
+          end
           nil
         end
       end

--- a/lib/universal_renderer/client/stream.rb
+++ b/lib/universal_renderer/client/stream.rb
@@ -22,9 +22,11 @@ module UniversalRenderer
         config = UniversalRenderer.config
 
         unless Setup.ensure_ssr_server_url_configured?(config)
-          Rails.logger.warn(
-            "Stream: SSR URL (config.ssr_url) is not configured. Falling back."
-          )
+          UniversalRenderer.log do |log|
+            log.warn(
+              "Stream: SSR URL (config.ssr_url) is not configured. Falling back."
+            )
+          end
           return false
         end
 
@@ -41,9 +43,11 @@ module UniversalRenderer
 
           full_ssr_url_for_log = actual_stream_uri.to_s # Update for more specific logging
         rescue URI::InvalidURIError => e
-          Rails.logger.error(
-            "Stream: SSR stream failed due to invalid URI ('#{config.ssr_url}'): #{e.message}"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "Stream: SSR stream failed due to invalid URI ('#{config.ssr_url}'): #{e.message}"
+            )
+          end
           return false
         rescue StandardError => e
           log_setup_error(e, full_ssr_url_for_log)

--- a/lib/universal_renderer/client/stream/error_logger.rb
+++ b/lib/universal_renderer/client/stream/error_logger.rb
@@ -4,24 +4,30 @@ module UniversalRenderer
       module ErrorLogger
         def self.log_setup_error(error, target_uri_string)
           backtrace_info = error.backtrace&.first || "No backtrace available"
-          Rails.logger.error(
-            "Unexpected error during SSR stream setup for #{target_uri_string}: " \
-              "#{error.class.name} - #{error.message} at #{backtrace_info}"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "Unexpected error during SSR stream setup for #{target_uri_string}: " \
+                "#{error.class.name} - #{error.message} at #{backtrace_info}"
+            )
+          end
         end
 
         def self.log_connection_error(error, target_uri_string)
-          Rails.logger.error(
-            "SSR stream connection to #{target_uri_string} failed: #{error.class.name} - #{error.message}"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "SSR stream connection to #{target_uri_string} failed: #{error.class.name} - #{error.message}"
+            )
+          end
         end
 
         def self.log_unexpected_error(error, target_uri_string, context_message)
           backtrace_info = error.backtrace&.first || "No backtrace available"
-          Rails.logger.error(
-            "#{context_message} for #{target_uri_string}: " \
-              "#{error.class.name} - #{error.message} at #{backtrace_info}"
-          )
+          UniversalRenderer.log do |log|
+            log.error(
+              "#{context_message} for #{target_uri_string}: " \
+                "#{error.class.name} - #{error.message} at #{backtrace_info}"
+            )
+          end
         end
       end
     end

--- a/lib/universal_renderer/client/stream/execution.rb
+++ b/lib/universal_renderer/client/stream/execution.rb
@@ -28,15 +28,19 @@ module UniversalRenderer
                 end
                 success = true
               else
-                Rails.logger.error(
-                  "SSR stream server at #{stream_uri} responded with #{node_res.code} #{node_res.message}."
-                )
+                UniversalRenderer.log do |log|
+                  log.error(
+                    "SSR stream server at #{stream_uri} responded with #{node_res.code} #{node_res.message}."
+                  )
+                end
               end
             end
           rescue StandardError => e
-            Rails.logger.error(
-              "Error during SSR data transfer or stream writing from #{stream_uri}: #{e.class.name} - #{e.message}"
-            )
+            UniversalRenderer.log do |log|
+              log.error(
+                "Error during SSR data transfer or stream writing from #{stream_uri}: #{e.class.name} - #{e.message}"
+              )
+            end
 
             # The response may be only partially consumed, so do not reuse the
             # current persistent connection. Net::HTTP can also raise after its

--- a/lib/universal_renderer/renderable.rb
+++ b/lib/universal_renderer/renderable.rb
@@ -77,10 +77,12 @@ module UniversalRenderer
 
       # Check if the current adapter supports streaming
       unless adapter.supports_streaming?
-        Rails.logger.warn(
-          "Current SSR adapter (#{adapter.class.name}) does not support streaming. " \
-            "Falling back to blocking SSR."
-        )
+        UniversalRenderer.log do |log|
+          log.warn(
+            "Current SSR adapter (#{adapter.class.name}) does not support streaming. " \
+              "Falling back to blocking SSR."
+          )
+        end
         return false
       end
 
@@ -100,10 +102,12 @@ module UniversalRenderer
         response.stream.close unless response.stream.closed?
         true
       else
-        Rails.logger.error(
-          "SSR stream fallback: " \
-            "Streaming failed, proceeding with standard rendering."
-        )
+        UniversalRenderer.log do |log|
+          log.error(
+            "SSR stream fallback: " \
+              "Streaming failed, proceeding with standard rendering."
+          )
+        end
         false
       end
     end

--- a/spec/units/adapter/stdio_spec.rb
+++ b/spec/units/adapter/stdio_spec.rb
@@ -8,10 +8,11 @@ RSpec.describe UniversalRenderer::Adapter::Stdio do
     # Mock Rails.root
     allow(Rails).to receive(:root).and_return(Pathname.new("/fake/rails/root"))
 
-    # Mock Rails.logger
-    allow(Rails.logger).to receive(:info)
-    allow(Rails.logger).to receive(:error)
-    allow(Rails.logger).to receive(:warn)
+    # Mock UniversalRenderer logger
+    allow(UniversalRenderer).to receive(:logger).and_return(Rails.logger)
+    allow(UniversalRenderer).to receive(:log) do |&block|
+      block.call(Rails.logger)
+    end
 
     # Mock UniversalRenderer.config
     allow(UniversalRenderer).to receive(:config).and_return(config_mock)
@@ -44,7 +45,7 @@ RSpec.describe UniversalRenderer::Adapter::Stdio do
 
       it "logs successful initialization" do
         expect(Rails.logger).to receive(:info).with(
-          "Universal Renderer Stdio process pool (2) initialized"
+          "Stdio process pool (2) initialized"
         )
 
         described_class.new

--- a/spec/units/adapter_factory_spec.rb
+++ b/spec/units/adapter_factory_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe UniversalRenderer::AdapterFactory do
 
   before do
     described_class.reset!
-    allow(Rails).to receive(:logger).and_return(logger)
+    allow(UniversalRenderer).to receive(:logger).and_return(logger)
+    allow(UniversalRenderer).to receive(:log).and_yield(logger)
   end
 
   after { described_class.reset! }

--- a/spec/units/client/stream_execution_spec.rb
+++ b/spec/units/client/stream_execution_spec.rb
@@ -31,6 +31,10 @@ RSpec.describe UniversalRenderer::Client::Stream::Execution do
   let(:response) { double("response", stream: stream) }
 
   before do
+    allow(UniversalRenderer).to receive(:logger).and_return(Rails.logger)
+    allow(UniversalRenderer).to receive(:log) do |&block|
+      block.call(Rails.logger)
+    end
     allow(Rails.logger).to receive(:error)
   end
 


### PR DESCRIPTION
## Problem

The gem hardcoded `Rails.logger` throughout `lib/`. This is an anti-pattern for Rails engine gems because it:

- couples the gem to the host's logger
- blocks host apps from routing gem output elsewhere (separate file, custom formatter, semantic-logging backend)
- forces ad-hoc string prefixes (`[stdio-ssr]`, `\"Universal Renderer ...\"`, `\"Stream:\"`) instead of a uniform tag

## Solution

Followed the documented Rails-gem best practice (configurable logger + `ActiveSupport::TaggedLogging`):

- Added `UniversalRenderer.logger`, which defaults to the host's `Rails.logger` (when present) wrapped in `ActiveSupport::TaggedLogging`, falling back to `ActiveSupport::Logger.new($stdout)` when Rails isn't loaded.
- `UniversalRenderer.logger = MyLogger.new` lets host apps inject any logger; `nil` restores the default.
- `UniversalRenderer.log { |log| log.error(\"...\") }` wraps a block in `tagged(\"UniversalRenderer\")`, so every line is auto-prefixed with `[UniversalRenderer]` and callers don't need to remember a prefix.

Replaced all `Rails.logger.<level>` call sites with `UniversalRenderer.log { |log| log.<level>(...) }` and dropped now-redundant manual prefixes.

## Files

- `lib/universal_renderer.rb` — configurable logger + `log` helper
- `lib/universal_renderer/adapter/stdio.rb`, `client/base.rb`, `client/stream.rb`, `client/stream/error_logger.rb`, `client/stream/execution.rb`, `adapter_factory.rb`, `renderable.rb` — call-site migration
- `spec/units/adapter_factory_spec.rb`, `adapter/stdio_spec.rb`, `client/stream_execution_spec.rb` — stub `UniversalRenderer.logger`/`log` instead of `Rails.logger`; updated the one changed message expectation
- `README.md` — documented the logger with an override example

## Verification

- All 55 unit specs pass.
- No `Rails.logger` references remain in `lib/` (only the intentional default-fallback references in `universal_renderer.rb`).
- The full-suite hang is the pre-existing integration specs that spawn real bun processes / HTTP servers — unrelated to these changes.