### PR TITLE
Decouple configuration from ENV, nest adapter options, demote stdio

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Ruby Gem
+
+#### Changed (breaking)
+
+- Reworked configuration handling so `UniversalRenderer::Configuration` no
+  longer reads environment variables itself; it only exposes plain attributes
+  with sensible defaults. Binding those values to `ENV` is left entirely to
+  the host application. The suggested env-var convention is the
+  `UNIVERSAL_RENDERER_*` prefix (documented in the README); the `SSR_*` env
+  vars are no longer referenced anywhere in the gem.
+- Renamed `config.engine` to `config.adapter`.
+- Renamed `config.ssr_url` to `config.url`, `config.ssr_stream_path` to
+  `config.stream_path`.
+- Nested adapter-specific options under sub-objects: `config.http.pool_size`
+  (was `config.http_pool_size`), `config.stdio.pool_size` (was
+  `config.stdio_pool_size`), `config.stdio.timeout_ms` (was
+  `config.stdio_timeout`), and `config.stdio.cli_script` (was
+  `config.stdio_cli_script`).
+
+#### Changed
+
+- The stdio adapter is now **experimental** and is lazily loaded: it is only
+  required when `config.adapter = :stdio` is set, so it never affects the
+  default (HTTP) boot path. It is no longer recommended for production.
+
+### Documentation
+
+- README and install generator now lead with the HTTP adapter as the
+  production-recommended path; stdio is documented as experimental.
+
 ## 0.4.4 - 2025-06-29
 
 ### Ruby Gem

--- a/README.md
+++ b/README.md
@@ -43,27 +43,40 @@ UniversalRenderer helps you forward rendering requests to external SSR services,
 Configure in `config/initializers/universal_renderer.rb`:
 
 ```ruby
-UniversalRenderer.configure do |config|
-  # Choose your SSR engine:
-  # :http           - External Node.js server (default)
-  # :stdio          - Stdio Bun processes via Open3 (no external server)
-  # Both engines support blocking and streaming SSR.
-  config.engine = :http
+UniversalRenderer.configure do |c|
+  # Choose your SSR adapter:
+  # :http  - External Node.js/Bun server (default, recommended for production)
+  # :stdio - EXPERIMENTAL. Stdio Bun processes via Open3 (no external server)
+  # Both adapters support blocking and streaming SSR.
+  c.adapter = :http
   # HTTP is recommended for most applications, including production.
-  # Choose :stdio only when you want embedded SSR instead of a separate service.
+  # Choose :stdio only for embedded SSR; it is experimental and not
+  # recommended for production.
 
-  # HTTP Engine Configuration (when engine = :http)
-  config.ssr_url = "http://localhost:3001"
-  config.timeout = 3
-  config.http_pool_size = 5 # persistent Net::HTTP connections per SSR origin
+  # HTTP adapter configuration (when adapter = :http)
+  c.url = "http://localhost:3001"
+  c.timeout = 3
+  c.stream_path = "/stream"
+  c.http.pool_size = 5 # persistent Net::HTTP connections per SSR origin
 
-  # HTTP configuration can also use environment variables:
-  # SSR_HTTP_POOL_SIZE (default: 5)
+  # --- Stdio adapter (EXPERIMENTAL, when adapter = :stdio) -------------
+  # c.stdio.pool_size = 5
+  # c.stdio.timeout_ms = 5_000
+  # c.stdio.cli_script = "app/frontend/ssr/stdio.tsx"
+end
+```
 
-  # Stdio configuration is handled via environment variables:
-  # SSR_STDIO_POOL_SIZE (default: 5)
-  # SSR_STDIO_TIMEOUT (default: 5000ms)
-  # SSR_STDIO_CLI_SCRIPT (default: "app/frontend/ssr/stdio.tsx")
+The gem itself never reads environment variables; it only exposes the plain
+configuration attributes above with sensible defaults. Binding those values to
+`ENV` is entirely up to you, in your own initializer, using whatever keys you
+like. If you want a convention, the suggested env-var prefix is
+`UNIVERSAL_RENDERER_*` (e.g. `UNIVERSAL_RENDERER_URL`):
+
+```ruby
+UniversalRenderer.configure do |c|
+  c.url = ENV.fetch("UNIVERSAL_RENDERER_URL", "http://localhost:3001")
+  c.timeout = ENV.fetch("UNIVERSAL_RENDERER_TIMEOUT", 3).to_i
+  # ...
 end
 ```
 
@@ -84,15 +97,16 @@ UniversalRenderer.logger = Logger.new("log/universal_renderer.log")
 ```
 
 Setting it back to `nil` restores the default tagged `Rails.logger`.
-```
 
-## SSR Engines
+````
 
-UniversalRenderer supports two SSR engine modes:
+## SSR Adapters
 
-### HTTP Engine (Default)
+UniversalRenderer supports two SSR adapter modes:
 
-The HTTP engine forwards SSR requests to an external Node.js server. This is the default and recommended approach for most applications.
+### HTTP Adapter (Default)
+
+The HTTP adapter forwards SSR requests to an external Node.js/Bun server. This is the default and recommended approach for most applications, including production.
 
 **Pros:**
 
@@ -107,9 +121,11 @@ The HTTP engine forwards SSR requests to an external Node.js server. This is the
 - HTTP serialization overhead for each request, though persistent connections are reused
 - Additional infrastructure complexity
 
-### Stdio Engine
+### Stdio Adapter (Experimental)
 
-The Stdio engine maintains a pool of stdio Bun processes and communicates with them via stdin/stdout for server-side rendering.
+> **Warning:** The stdio adapter is **experimental** and less battle-tested than the HTTP adapter. It is not recommended for production. Use it only when you need embedded SSR inside the Rails process and accept the operational trade-offs.
+
+The stdio adapter maintains a pool of stdio Bun processes and communicates with them via stdin/stdout for server-side rendering. It is lazily loaded: the stdio adapter code is only required when `config.adapter = :stdio` is set, so it never affects the default (HTTP) boot path.
 
 **Pros:**
 
@@ -123,15 +139,17 @@ The Stdio engine maintains a pool of stdio Bun processes and communicates with t
 
 - Memory overhead per long-lived process
 - Not suitable for complex JavaScript applications
+- Experimental; not recommended for production
 
-### Selecting the engine per environment
+### Selecting the adapter per environment
 
 HTTP is the safest default for most environments, including production, because it
 keeps the SSR runtime separately observable, restartable, and scalable. Choose
-`:stdio` when you explicitly want embedded SSR inside the Rails deployment and
-are comfortable sizing and operating the Bun process pool with the Rails app.
+`:stdio` only when you explicitly want embedded SSR inside the Rails deployment,
+are comfortable sizing and operating the Bun process pool with the Rails app, and
+accept that this adapter is experimental.
 
-If production uses `:stdio`, ensure Bun and the configured stdio script are available
+If you do use `:stdio`, ensure Bun and the configured stdio script are available
 before boot. The script can be a `.ts` / `.tsx` entrypoint or a prebuilt bundle.
 
 ## Basic Usage
@@ -151,7 +169,7 @@ enable_ssr
 
 # Streaming SSR (only use if you need fast TTFB)
 enable_ssr streaming: true
-```
+````
 
 ```ruby
 class ProductsController < ApplicationController
@@ -327,15 +345,15 @@ To set up the SSR server for your Rails application:
    ssr: bin/vite ssr
    ```
 
-## Setting Up Stdio Engine
+## Setting Up the Stdio Adapter (Experimental)
 
-If you prefer to use the stdio engine instead of an external HTTP server:
+If you prefer to use the stdio adapter instead of an external HTTP server (experimental, not recommended for production):
 
-1. Configure the engine in your initializer:
+1. Configure the adapter in your initializer:
 
    ```ruby
    # config/initializers/universal_renderer.rb
-   UniversalRenderer.configure { |config| config.engine = :stdio }
+   UniversalRenderer.configure { |config| config.adapter = :stdio }
    ```
 
 2. Create a persistent CLI script (e.g., `app/frontend/ssr/stdio.tsx`):

--- a/benchmark/http-vs-stdio.rb
+++ b/benchmark/http-vs-stdio.rb
@@ -44,7 +44,11 @@ ITERATIONS = Integer(ENV.fetch("ITERATIONS", "300"))
 WARMUP = Integer(ENV.fetch("WARMUP", "25"))
 RESULTS_DIR = File.expand_path("../tmp/reports", __dir__)
 RESULTS_FILE = File.join(RESULTS_DIR, "http-vs-stdio.json")
-STDIO_SCRIPT = ENV.fetch("SSR_STDIO_CLI_SCRIPT", "benchmark/stdio-renderer.ts")
+STDIO_SCRIPT =
+  ENV.fetch(
+    "UNIVERSAL_RENDERER_STDIO_CLI_SCRIPT",
+    "benchmark/stdio-renderer.ts"
+  )
 SCENARIOS =
   ENV
     .fetch("SCENARIOS", "basic,props-heavy,react-stack")
@@ -57,13 +61,14 @@ DEFAULT_ITEM_COUNTS = {
   "react-stack" => 125
 }.freeze
 
-UniversalRenderer.config.ssr_url = ENV.fetch("SSR_SERVER_URL")
-UniversalRenderer.config.timeout = Integer(ENV.fetch("SSR_TIMEOUT", "15"))
-UniversalRenderer.config.stdio_cli_script = STDIO_SCRIPT
-UniversalRenderer.config.stdio_timeout =
-  Integer(ENV.fetch("SSR_STDIO_TIMEOUT", "15000"))
-UniversalRenderer.config.stdio_pool_size =
-  Integer(ENV.fetch("SSR_STDIO_POOL_SIZE", "1"))
+UniversalRenderer.config.url = ENV.fetch("UNIVERSAL_RENDERER_URL")
+UniversalRenderer.config.timeout =
+  Integer(ENV.fetch("UNIVERSAL_RENDERER_TIMEOUT", "15"))
+UniversalRenderer.config.stdio.cli_script = STDIO_SCRIPT
+UniversalRenderer.config.stdio.timeout_ms =
+  Integer(ENV.fetch("UNIVERSAL_RENDERER_STDIO_TIMEOUT_MS", "15000"))
+UniversalRenderer.config.stdio.pool_size =
+  Integer(ENV.fetch("UNIVERSAL_RENDERER_STDIO_POOL_SIZE", "1"))
 
 def monotonic_ms
   Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1000.0
@@ -213,8 +218,8 @@ def strip_runtime_objects(result)
 end
 
 puts "UniversalRenderer benchmark: HTTP vs Stdio"
-puts "iterations=#{ITERATIONS}, warmup=#{WARMUP}, scenarios=#{SCENARIOS.join(",")}, stdio_pool_size=#{UniversalRenderer.config.stdio_pool_size}"
-puts "http_url=#{UniversalRenderer.config.ssr_url}, stdio_script=#{UniversalRenderer.config.stdio_cli_script}"
+puts "iterations=#{ITERATIONS}, warmup=#{WARMUP}, scenarios=#{SCENARIOS.join(",")}, stdio_pool_size=#{UniversalRenderer.config.stdio.pool_size}"
+puts "http_url=#{UniversalRenderer.config.url}, stdio_script=#{UniversalRenderer.config.stdio.cli_script}"
 puts
 
 scenario_results =
@@ -224,11 +229,11 @@ scenario_results =
 
     puts "#{scenario} (items=#{props.fetch("items").length}, props=#{props_bytes} bytes)"
 
-    UniversalRenderer.config.engine = :http
+    UniversalRenderer.config.adapter = :http
     http_result = measure("HTTP", props)
     print_result("HTTP", http_result)
 
-    UniversalRenderer.config.engine = :stdio
+    UniversalRenderer.config.adapter = :stdio
     stdio_result = measure("Stdio", props)
     print_result("Stdio", stdio_result)
     shutdown_stdio(stdio_result.fetch("adapter"))
@@ -268,9 +273,9 @@ output = {
   "generated_at" => Time.now.utc.iso8601,
   "iterations" => ITERATIONS,
   "warmup" => WARMUP,
-  "http_url" => UniversalRenderer.config.ssr_url,
-  "stdio_script" => UniversalRenderer.config.stdio_cli_script,
-  "stdio_pool_size" => UniversalRenderer.config.stdio_pool_size,
+  "http_url" => UniversalRenderer.config.url,
+  "stdio_script" => UniversalRenderer.config.stdio.cli_script,
+  "stdio_pool_size" => UniversalRenderer.config.stdio.pool_size,
   "scenarios" => scenario_results
 }
 File.write(RESULTS_FILE, JSON.pretty_generate(output))

--- a/benchmark/run.ts
+++ b/benchmark/run.ts
@@ -117,9 +117,9 @@ async function main() {
         stdio: "inherit",
         env: {
           ...globalThis.process.env,
-          SSR_SERVER_URL: `http://127.0.0.1:${port}/`,
-          SSR_STDIO_CLI_SCRIPT:
-            globalThis.process.env.SSR_STDIO_CLI_SCRIPT ??
+          UNIVERSAL_RENDERER_URL: `http://127.0.0.1:${port}/`,
+          UNIVERSAL_RENDERER_STDIO_CLI_SCRIPT:
+            globalThis.process.env.UNIVERSAL_RENDERER_STDIO_CLI_SCRIPT ??
             "benchmark/stdio-renderer.ts",
         },
       },

--- a/examples/universal_renderer_demo/README.md
+++ b/examples/universal_renderer_demo/README.md
@@ -3,6 +3,7 @@
 This app is a minimal integration example for the `universal_renderer` gem.
 
 It uses:
+
 - Ruby on Rails
 - `vite_rails`
 - Bun
@@ -38,7 +39,7 @@ SSR setup/render handlers are shared in `app/frontend/ssr/setup.tsx`.
 
 The HTTP SSR server is run from `app/frontend/ssr/ssr.tsx` via `Procfile.dev`.
 For a production-style run, build and start `public/vite-ssr-http/ssr.js` with
-Bun and set `SSR_SERVER_URL` to its address.
+Bun and set `UNIVERSAL_RENDERER_URL` to its address.
 
 ## Production build note
 
@@ -57,6 +58,7 @@ bun public/vite-ssr-http/ssr.js
 ```
 
 To test larger SSR payloads and more query seed data, use:
+
 - `http://127.0.0.1:3000/?records=50&size_kb=16`
 - `http://127.0.0.1:3000/?records=500&size_kb=128`
 - `http://127.0.0.1:3000/?records=1000&size_kb=256`

--- a/examples/universal_renderer_demo/config/initializers/universal_renderer.rb
+++ b/examples/universal_renderer_demo/config/initializers/universal_renderer.rb
@@ -1,10 +1,9 @@
 UniversalRenderer.configure do |c|
   # The HTTP adapter uses the external Bun SSR server configured in Procfile.dev.
   # It supports streaming via the /stream endpoint.
-  c.engine = :http
+  c.adapter = :http
 
-  # HTTP Engine Configuration (when engine = :http)
-  c.ssr_url = ENV.fetch("SSR_SERVER_URL", "http://localhost:5200")
+  c.url = "http://localhost:5200"
   c.timeout = 3
-  c.ssr_stream_path = "/stream"
+  c.stream_path = "/stream"
 end

--- a/lib/generators/universal_renderer/install_generator.rb
+++ b/lib/generators/universal_renderer/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module UniversalRenderer
   class InstallGenerator < Rails::Generators::Base
     source_root File.expand_path("templates", __dir__)
@@ -8,16 +10,10 @@ module UniversalRenderer
 
     def show_installation_notes
       say_status "info", "Universal Renderer installed successfully!"
-      say_status "note", "To use stdio (process pool):"
-      say_status "", "  1. Set config.engine = :stdio in your initializer"
+      say_status "note", "Next steps:"
       say_status "",
-                 "  2. Create a stdio CLI script (e.g., app/frontend/ssr/stdio.tsx)"
-      say_status "",
-                 "  3. Configure the CLI script path if using a custom location"
-      say_status "", "  4. Ensure Bun is installed and accessible"
-      say_status "note", "To use HTTP server (external Node.js):"
-      say_status "", "  1. Keep config.engine = :http (default)"
-      say_status "", "  2. Set SSR_SERVER_URL environment variable"
+                 "  1. Edit config/initializers/universal_renderer.rb to point at your SSR server"
+      say_status "", "  2. Ensure your Node.js/Bun SSR server is running"
     end
   end
 end

--- a/lib/generators/universal_renderer/templates/initializer.rb
+++ b/lib/generators/universal_renderer/templates/initializer.rb
@@ -1,27 +1,14 @@
+# frozen_string_literal: true
+
 UniversalRenderer.configure do |c|
-  # Choose your SSR engine:
-  # :http           - External Node.js server (default, supports streaming)
-  # :stdio          - Stdio Bun processes via Open3 (supports streaming, no external server)
-  c.engine = :http
-  # HTTP is recommended for most applications, including production.
-  # Choose :stdio only when you want embedded SSR instead of a separate service.
+  # External Node.js/Bun SSR server. Supports streaming via the /stream endpoint.
+  c.adapter = :http
 
-  # HTTP Engine Configuration (when engine = :http)
-  c.ssr_url = ENV.fetch("SSR_SERVER_URL", "http://localhost:3001")
+  c.url = "http://localhost:3001"
   c.timeout = 3
-  c.ssr_stream_path = "/stream"
-  c.http_pool_size = ENV.fetch("SSR_HTTP_POOL_SIZE", 5).to_i
-
-  # Stdio Engine Configuration (when engine = :stdio)
-  # These can also be set via environment variables:
-  # SSR_STDIO_POOL_SIZE, SSR_STDIO_TIMEOUT, SSR_STDIO_CLI_SCRIPT
-  c.stdio_pool_size = 5
-  c.stdio_timeout = 5_000
-  c.stdio_cli_script = "app/frontend/ssr/stdio.tsx"
+  c.stream_path = "/stream"
+  c.http.pool_size = 5
 
   # Blocking SSR is the default. Enable streaming per controller only when needed:
   # enable_ssr streaming: true
-
-  # NOTE: When using Stdio, ensure you have a Bun-executable stdio CLI script that can handle
-  # JSON input/output with head/body/body_attrs response format.
 end

--- a/lib/universal_renderer/adapter/stdio.rb
+++ b/lib/universal_renderer/adapter/stdio.rb
@@ -10,9 +10,10 @@ module UniversalRenderer
     class Stdio < Base
       def initialize
         super
-        @pool_size = UniversalRenderer.config.stdio_pool_size
-        @timeout = UniversalRenderer.config.stdio_timeout
-        @cli_script = UniversalRenderer.config.stdio_cli_script
+        stdio_config = UniversalRenderer.config.stdio
+        @pool_size = stdio_config.pool_size
+        @timeout = stdio_config.timeout_ms
+        @cli_script = stdio_config.cli_script
         @process_pool = nil
         setup
       end
@@ -76,9 +77,7 @@ module UniversalRenderer
         true
       rescue StandardError => e
         UniversalRenderer.log do |log|
-          log.error(
-            "Stdio SSR stream failed (URL: #{url}): #{e.full_message}"
-          )
+          log.error("Stdio SSR stream failed (URL: #{url}): #{e.full_message}")
         end
 
         # Once bytes have reached the response stream a fallback render would
@@ -119,9 +118,7 @@ module UniversalRenderer
             ) { StdioProcess.new(script, timeout_ms: timeout_ms) }
 
           UniversalRenderer.log do |log|
-            log.info(
-              "Stdio process pool (#{@pool_size}) initialized"
-            )
+            log.info("Stdio process pool (#{@pool_size}) initialized")
           end
         rescue StandardError => e
           UniversalRenderer.log do |log|

--- a/lib/universal_renderer/adapter_factory.rb
+++ b/lib/universal_renderer/adapter_factory.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "adapter/http"
-require_relative "adapter/stdio"
 
 module UniversalRenderer
   class AdapterFactory
@@ -9,22 +8,26 @@ module UniversalRenderer
       # Creates and returns the appropriate adapter based on configuration
       # @return [UniversalRenderer::Adapter::Base] The configured adapter
       def create_adapter
-        engine = UniversalRenderer.config.engine
+        adapter = UniversalRenderer.config.adapter
         UniversalRenderer.log do |log|
           log.info(
-            "Resolved SSR engine '#{engine}' for Rails env '#{Rails.env}'"
+            "Resolved SSR adapter '#{adapter}' for Rails env '#{Rails.env}'"
           )
         end
 
-        case engine
+        case adapter
         when :http
           Adapter::Http.new
         when :stdio
+          # The stdio adapter is experimental and lazily loaded so it never
+          # affects the default (HTTP) boot path. It is only required when a
+          # host application explicitly opts into `config.adapter = :stdio`.
+          require_relative "adapter/stdio"
           Adapter::Stdio.new
         else
           UniversalRenderer.log do |log|
             log.warn(
-              "Unknown SSR engine '#{engine}'. Falling back to HTTP adapter."
+              "Unknown SSR adapter '#{adapter}'. Falling back to HTTP adapter."
             )
           end
           Adapter::Http.new

--- a/lib/universal_renderer/client/base.rb
+++ b/lib/universal_renderer/client/base.rb
@@ -25,7 +25,7 @@ module UniversalRenderer
       #   (HTTP 2xx). Returns `nil` when the request fails or the SSR service is
       #   unreachable.
       def self.call(url, props)
-        ssr_url = UniversalRenderer.config.ssr_url
+        ssr_url = UniversalRenderer.config.url
         return if ssr_url.blank?
 
         timeout = UniversalRenderer.config.timeout

--- a/lib/universal_renderer/client/http_pool.rb
+++ b/lib/universal_renderer/client/http_pool.rb
@@ -45,9 +45,7 @@ module UniversalRenderer
 
         def reset!
           mutex.synchronize do
-            pools.each_value do |pool|
-              pool.shutdown { |http| close(http) }
-            end
+            pools.each_value { |pool| pool.shutdown { |http| close(http) } }
             pools.clear
           end
         end
@@ -74,18 +72,21 @@ module UniversalRenderer
           key = pool_key(uri, timeout)
 
           mutex.synchronize do
-            pools[key] ||= ConnectionPool.new(size: pool_size, timeout: timeout) do
-              build_connection(uri, timeout)
-            end
+            pools[key] ||= ConnectionPool.new(
+              size: pool_size,
+              timeout: timeout
+            ) { build_connection(uri, timeout) }
           end
         end
 
         def build_connection(uri, timeout)
-          Net::HTTP.new(uri.host, uri.port).tap do |http|
-            http.use_ssl = (uri.scheme == "https")
-            http.open_timeout = timeout
-            http.read_timeout = timeout
-          end
+          Net::HTTP
+            .new(uri.host, uri.port)
+            .tap do |http|
+              http.use_ssl = (uri.scheme == "https")
+              http.open_timeout = timeout
+              http.read_timeout = timeout
+            end
         end
 
         def ensure_started(http)
@@ -97,7 +98,7 @@ module UniversalRenderer
         end
 
         def pool_size
-          UniversalRenderer.config.http_pool_size
+          UniversalRenderer.config.http.pool_size
         end
 
         def pools

--- a/lib/universal_renderer/client/stream.rb
+++ b/lib/universal_renderer/client/stream.rb
@@ -24,14 +24,14 @@ module UniversalRenderer
         unless Setup.ensure_ssr_server_url_configured?(config)
           UniversalRenderer.log do |log|
             log.warn(
-              "Stream: SSR URL (config.ssr_url) is not configured. Falling back."
+              "Stream: SSR URL (config.url) is not configured. Falling back."
             )
           end
           return false
         end
 
         stream_uri_obj = nil
-        full_ssr_url_for_log = config.ssr_url.to_s # For logging in case of early error
+        full_ssr_url_for_log = config.url.to_s # For logging in case of early error
 
         begin
           body = { url: url, props: props, template: template }
@@ -45,7 +45,7 @@ module UniversalRenderer
         rescue URI::InvalidURIError => e
           UniversalRenderer.log do |log|
             log.error(
-              "Stream: SSR stream failed due to invalid URI ('#{config.ssr_url}'): #{e.message}"
+              "Stream: SSR stream failed due to invalid URI ('#{config.url}'): #{e.message}"
             )
           end
           return false

--- a/lib/universal_renderer/client/stream/setup.rb
+++ b/lib/universal_renderer/client/stream/setup.rb
@@ -5,18 +5,16 @@ module UniversalRenderer
     class Stream
       module Setup
         def self.ensure_ssr_server_url_configured?(config)
-          config.ssr_url.present?
+          config.url.present?
         end
 
         def self.build_stream_request_components(body, config)
           # Ensure ssr_url is present, though ensure_ssr_server_url_configured? should have caught this.
-          # However, direct calls to this method might occur, so a check or reliance on config.ssr_url is important.
-          if config.ssr_url.blank?
-            raise ArgumentError, "SSR URL is not configured."
-          end
+          # However, direct calls to this method might occur, so a check or reliance on config.url is important.
+          raise ArgumentError, "SSR URL is not configured." if config.url.blank?
 
-          parsed_ssr_url = URI.parse(config.ssr_url)
-          stream_uri = URI.join(parsed_ssr_url, config.ssr_stream_path)
+          parsed_ssr_url = URI.parse(config.url)
+          stream_uri = URI.join(parsed_ssr_url, config.stream_path)
 
           http = HttpPool.client(stream_uri, config.timeout)
 

--- a/lib/universal_renderer/configuration.rb
+++ b/lib/universal_renderer/configuration.rb
@@ -1,28 +1,52 @@
-module UniversalRenderer
-  class Configuration
-    attr_accessor :ssr_url,
-                  :timeout,
-                  :ssr_stream_path,
-                  :http_pool_size,
-                  :stdio_pool_size,
-                  :stdio_timeout,
-                  :stdio_cli_script
-    attr_reader :engine
+# frozen_string_literal: true
 
-    def initialize
-      @ssr_url = ENV.fetch("SSR_SERVER_URL", nil)
-      @timeout = (ENV["SSR_TIMEOUT"] || 3).to_i
-      @ssr_stream_path = ENV.fetch("SSR_STREAM_PATH", "/stream")
-      @http_pool_size = ENV.fetch("SSR_HTTP_POOL_SIZE", 5).to_i
-      self.engine = ENV.fetch("SSR_ENGINE", :http)
-      @stdio_pool_size = ENV.fetch("SSR_STDIO_POOL_SIZE", 5).to_i
-      @stdio_timeout = ENV.fetch("SSR_STDIO_TIMEOUT", 5_000).to_i
-      @stdio_cli_script =
-        ENV.fetch("SSR_STDIO_CLI_SCRIPT", "app/frontend/ssr/stdio.tsx")
+module UniversalRenderer
+  # Configuration for UniversalRenderer.
+  #
+  # This object holds plain Ruby defaults only. It never reads environment
+  # variables itself; binding configuration to ENV is the host application's
+  # responsibility, done in the initializer (see the generated
+  # config/initializers/universal_renderer.rb). The documented env-var
+  # convention is the `UNIVERSAL_RENDERER_*` prefix.
+  class Configuration
+    # HTTP adapter options. Applies only when `config.adapter == :http`.
+    class Http
+      attr_accessor :pool_size
+
+      def initialize
+        @pool_size = 5
+      end
     end
 
-    def engine=(value)
-      @engine = value.to_s.downcase.to_sym
+    # Stdio adapter options. Applies only when `config.adapter == :stdio`.
+    #
+    # NOTE: The stdio adapter is experimental and less battle-tested than the
+    # HTTP adapter. It is intended for embedded, single-process deployments and
+    # is not recommended for production.
+    class Stdio
+      attr_accessor :pool_size, :timeout_ms, :cli_script
+
+      def initialize
+        @pool_size = 5
+        @timeout_ms = 5_000
+        @cli_script = "app/frontend/ssr/stdio.tsx"
+      end
+    end
+
+    attr_accessor :url, :timeout, :stream_path
+    attr_reader :adapter, :http, :stdio
+
+    def initialize
+      @adapter = :http
+      @url = nil
+      @timeout = 3
+      @stream_path = "/stream"
+      @http = Http.new
+      @stdio = Stdio.new
+    end
+
+    def adapter=(value)
+      @adapter = value.to_s.downcase.to_sym
     end
   end
 end

--- a/spec/integration/client_integration_tester.rb
+++ b/spec/integration/client_integration_tester.rb
@@ -11,8 +11,8 @@ module ClientIntegrationTester
     results = {}
 
     # Configure the gem to use our test server
-    original_ssr_url = UniversalRenderer.config.ssr_url
-    UniversalRenderer.config.ssr_url = base_url
+    original_ssr_url = UniversalRenderer.config.url
+    UniversalRenderer.config.url = base_url
 
     begin
       # Test UniversalRenderer::Client::Base
@@ -22,7 +22,7 @@ module ClientIntegrationTester
       results[:stream_client] = test_stream_client_integration
     ensure
       # Restore original configuration
-      UniversalRenderer.config.ssr_url = original_ssr_url
+      UniversalRenderer.config.url = original_ssr_url
     end
 
     results

--- a/spec/integration/integration_environment.rb
+++ b/spec/integration/integration_environment.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "socket"
+require "universal_renderer/adapter/stdio"
 
 module IntegrationEnvironment
   # Sets up integration test environment
@@ -53,12 +54,12 @@ module IntegrationEnvironment
   def configure_universal_renderer_for_tests(engine: :http)
     UniversalRenderer.configure do |config|
       config.timeout = ENV["CI"] ? 15 : 5 # Longer timeout in CI
-      config.engine = engine
+      config.adapter = engine
 
       if %i[stdio].include?(engine)
-        config.stdio_pool_size = 2
-        config.stdio_timeout = 3000
-        config.stdio_cli_script = "spec/fixtures/test_ssr.ts"
+        config.stdio.pool_size = 2
+        config.stdio.timeout_ms = 3000
+        config.stdio.cli_script = "spec/fixtures/test_ssr.ts"
       end
     end
   end

--- a/spec/integration/multi_engine_contract_spec.rb
+++ b/spec/integration/multi_engine_contract_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Multi-Engine Contract Integration", type: :integration do
       end
 
       it "handles adapter configuration correctly" do
-        expect(UniversalRenderer.config.engine).to eq(:stdio)
-        expect(UniversalRenderer.config.stdio_pool_size).to eq(2)
-        expect(UniversalRenderer.config.stdio_timeout).to eq(3000)
+        expect(UniversalRenderer.config.adapter).to eq(:stdio)
+        expect(UniversalRenderer.config.stdio.pool_size).to eq(2)
+        expect(UniversalRenderer.config.stdio.timeout_ms).to eq(3000)
       end
 
       it "processes rendering through stdio interface" do

--- a/spec/units/adapter/stdio_spec.rb
+++ b/spec/units/adapter/stdio_spec.rb
@@ -1,8 +1,12 @@
 require "rails_helper"
+require "universal_renderer/adapter/stdio"
 
 RSpec.describe UniversalRenderer::Adapter::Stdio do
   let(:cli_script) { "app/frontend/ssr/ssr.ts" }
   let(:config_mock) { instance_double(UniversalRenderer::Configuration) }
+  let(:stdio_config) do
+    instance_double(UniversalRenderer::Configuration::Stdio)
+  end
 
   before do
     # Mock Rails.root
@@ -10,16 +14,15 @@ RSpec.describe UniversalRenderer::Adapter::Stdio do
 
     # Mock UniversalRenderer logger
     allow(UniversalRenderer).to receive(:logger).and_return(Rails.logger)
-    allow(UniversalRenderer).to receive(:log) do |&block|
-      block.call(Rails.logger)
-    end
+    allow(UniversalRenderer).to receive(:log).and_yield(Rails.logger)
 
     # Mock UniversalRenderer.config
     allow(UniversalRenderer).to receive(:config).and_return(config_mock)
-    allow(config_mock).to receive_messages(
-      stdio_pool_size: 2,
-      stdio_timeout: 3000,
-      stdio_cli_script: cli_script
+    allow(config_mock).to receive(:stdio).and_return(stdio_config)
+    allow(stdio_config).to receive_messages(
+      pool_size: 2,
+      timeout_ms: 3000,
+      cli_script: cli_script
     )
   end
 

--- a/spec/units/adapter_factory_spec.rb
+++ b/spec/units/adapter_factory_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "universal_renderer/adapter/stdio"
+
 RSpec.describe UniversalRenderer::AdapterFactory do
   let(:logger) do
     instance_double(Logger, error: nil, warn: nil, info: nil, debug: nil)
@@ -14,9 +16,9 @@ RSpec.describe UniversalRenderer::AdapterFactory do
   after { described_class.reset! }
 
   describe ".create_adapter" do
-    context "when engine is :http" do
+    context "when adapter is :http" do
       before do
-        allow(UniversalRenderer.config).to receive(:engine).and_return(:http)
+        allow(UniversalRenderer.config).to receive(:adapter).and_return(:http)
       end
 
       it "returns an HTTP adapter" do
@@ -25,14 +27,20 @@ RSpec.describe UniversalRenderer::AdapterFactory do
       end
     end
 
-    context "when engine is :stdio" do
+    context "when adapter is :stdio" do
+      let(:stdio_config) do
+        instance_double(
+          UniversalRenderer::Configuration::Stdio,
+          pool_size: 2,
+          timeout_ms: 3000,
+          cli_script: "app/frontend/ssr/ssr.ts"
+        )
+      end
+
       before do
-        # Mock Stdio configuration options
         allow(UniversalRenderer.config).to receive_messages(
-          engine: :stdio,
-          stdio_pool_size: 2,
-          stdio_timeout: 3000,
-          stdio_cli_script: "app/frontend/ssr/ssr.ts"
+          adapter: :stdio,
+          stdio: stdio_config
         )
 
         # Mock file existence for CLI script
@@ -62,35 +70,15 @@ RSpec.describe UniversalRenderer::AdapterFactory do
       end
     end
 
-    context "when engine is stdio" do
+    context "when adapter is unknown" do
       before do
-        allow(UniversalRenderer.config).to receive_messages(
-          engine: :stdio,
-          stdio_pool_size: 2,
-          stdio_timeout: 3000,
-          stdio_cli_script: "app/frontend/ssr/ssr.ts"
+        allow(UniversalRenderer.config).to receive(:adapter).and_return(
+          :unknown
         )
-        allow(File).to receive(:exist?).and_return(true)
-        allow(Rails).to receive(:root).and_return(
-          Pathname.new("/mock/rails/root")
-        )
-        pool_mock = instance_double(ConnectionPool)
-        allow(ConnectionPool).to receive(:new).and_return(pool_mock)
-      end
-
-      it "returns a Stdio adapter" do
-        adapter = described_class.create_adapter
-        expect(adapter).to be_a(UniversalRenderer::Adapter::Stdio)
-      end
-    end
-
-    context "when engine is unknown" do
-      before do
-        allow(UniversalRenderer.config).to receive(:engine).and_return(:unknown)
       end
 
       it "logs a warning and returns HTTP adapter" do
-        expect(logger).to receive(:warn).with(/Unknown SSR engine/)
+        expect(logger).to receive(:warn).with(/Unknown SSR adapter/)
         adapter = described_class.create_adapter
         expect(adapter).to be_a(UniversalRenderer::Adapter::Http)
       end
@@ -99,7 +87,7 @@ RSpec.describe UniversalRenderer::AdapterFactory do
 
   describe ".adapter" do
     before do
-      allow(UniversalRenderer.config).to receive(:engine).and_return(:http)
+      allow(UniversalRenderer.config).to receive(:adapter).and_return(:http)
     end
 
     it "returns a singleton instance" do
@@ -111,7 +99,7 @@ RSpec.describe UniversalRenderer::AdapterFactory do
 
   describe ".reset!" do
     before do
-      allow(UniversalRenderer.config).to receive(:engine).and_return(:http)
+      allow(UniversalRenderer.config).to receive(:adapter).and_return(:http)
     end
 
     it "clears the cached adapter" do

--- a/spec/units/client/base_spec.rb
+++ b/spec/units/client/base_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe UniversalRenderer::Client::Base do
   before do
     UniversalRenderer::Client::HttpPool.reset!
-    UniversalRenderer.config.ssr_url = "http://ssr.example.test/render"
+    UniversalRenderer.config.url = "http://ssr.example.test/render"
     UniversalRenderer.config.timeout = 3
-    UniversalRenderer.config.http_pool_size = 1
+    UniversalRenderer.config.http.pool_size = 1
   end
 
   after { UniversalRenderer::Client::HttpPool.reset! }

--- a/spec/units/configuration_spec.rb
+++ b/spec/units/configuration_spec.rb
@@ -9,109 +9,77 @@ RSpec.describe UniversalRenderer::Configuration do
     end
 
     it "sets default values" do
-      expect(subject.engine).to eq(:http)
+      expect(subject.adapter).to eq(:http)
+      expect(subject.url).to be_nil
       expect(subject.timeout).to eq(3)
-      expect(subject.stdio_cli_script).to eq("app/frontend/ssr/stdio.tsx")
-      expect(subject.http_pool_size).to eq(5)
-      expect(subject.stdio_pool_size).to eq(5)
-      expect(subject.stdio_timeout).to eq(5_000)
+      expect(subject.stream_path).to eq("/stream")
+      expect(subject.http).to be_a(described_class::Http)
+      expect(subject.stdio).to be_a(described_class::Stdio)
     end
 
-    it "reads engine from environment variable" do
-      original_env = ENV.fetch("SSR_ENGINE", nil)
-      ENV["SSR_ENGINE"] = "stdio"
-
+    it "does not read environment variables" do
+      # The Configuration object holds plain Ruby defaults only and must not
+      # consult ENV. Binding to ENV is the host application's responsibility.
+      stub_const("ENV", {})
       config = described_class.new
-      expect(config.engine).to eq(:stdio)
 
-      ENV["SSR_ENGINE"] = original_env
-    end
-
-    it "normalizes engine assignments" do
-      subject.engine = "STDIO"
-      expect(subject.engine).to eq(:stdio)
-    end
-
-    it "reads stdio_cli_script from environment variable" do
-      original_env = ENV.fetch("SSR_STDIO_CLI_SCRIPT", nil)
-      ENV["SSR_STDIO_CLI_SCRIPT"] = "custom/path/to/ssr.ts"
-
-      config = described_class.new
-      expect(config.stdio_cli_script).to eq("custom/path/to/ssr.ts")
-
-      ENV["SSR_STDIO_CLI_SCRIPT"] = original_env
-    end
-
-    it "reads http_pool_size from environment variable" do
-      original_env = ENV.fetch("SSR_HTTP_POOL_SIZE", nil)
-      ENV["SSR_HTTP_POOL_SIZE"] = "10"
-
-      config = described_class.new
-      expect(config.http_pool_size).to eq(10)
-
-      ENV["SSR_HTTP_POOL_SIZE"] = original_env
-    end
-
-    it "reads stdio_pool_size from environment variable" do
-      original_env = ENV.fetch("SSR_STDIO_POOL_SIZE", nil)
-      ENV["SSR_STDIO_POOL_SIZE"] = "10"
-
-      config = described_class.new
-      expect(config.stdio_pool_size).to eq(10)
-
-      ENV["SSR_STDIO_POOL_SIZE"] = original_env
-    end
-
-    it "reads stdio_timeout from environment variable" do
-      original_env = ENV.fetch("SSR_STDIO_TIMEOUT", nil)
-      ENV["SSR_STDIO_TIMEOUT"] = "8000"
-
-      config = described_class.new
-      expect(config.stdio_timeout).to eq(8000)
-
-      ENV["SSR_STDIO_TIMEOUT"] = original_env
+      expect(config.adapter).to eq(:http)
+      expect(config.timeout).to eq(3)
+      expect(config.http.pool_size).to eq(5)
+      expect(config.stdio.pool_size).to eq(5)
+      expect(config.stdio.timeout_ms).to eq(5_000)
+      expect(config.stdio.cli_script).to eq("app/frontend/ssr/stdio.tsx")
     end
   end
 
-  describe "configuration attributes" do
-    it "has an engine attribute" do
-      expect(subject).to respond_to(:engine)
-      expect(subject).to respond_to(:engine=)
+  describe "#adapter=" do
+    it "normalizes adapter assignments to a downcased symbol" do
+      subject.adapter = "STDIO"
+      expect(subject.adapter).to eq(:stdio)
     end
 
-    it "has an ssr_url attribute" do
-      expect(subject).to respond_to(:ssr_url)
-      expect(subject).to respond_to(:ssr_url=)
+    it "accepts symbol and string values" do
+      subject.adapter = :http
+      expect(subject.adapter).to eq(:http)
+
+      subject.adapter = "stdio"
+      expect(subject.adapter).to eq(:stdio)
+    end
+  end
+
+  describe "top-level attributes" do
+    it "has mutable url, timeout, and stream_path attributes" do
+      subject.url = "http://example.test"
+      subject.timeout = 10
+      subject.stream_path = "/render"
+
+      expect(subject.url).to eq("http://example.test")
+      expect(subject.timeout).to eq(10)
+      expect(subject.stream_path).to eq("/render")
+    end
+  end
+
+  describe "http sub-configuration" do
+    it "has a mutable pool_size" do
+      subject.http.pool_size = 10
+      expect(subject.http.pool_size).to eq(10)
+    end
+  end
+
+  describe "stdio sub-configuration" do
+    it "has mutable pool_size, timeout_ms, and cli_script" do
+      subject.stdio.pool_size = 10
+      subject.stdio.timeout_ms = 8_000
+      subject.stdio.cli_script = "custom/path/to/ssr.ts"
+
+      expect(subject.stdio.pool_size).to eq(10)
+      expect(subject.stdio.timeout_ms).to eq(8_000)
+      expect(subject.stdio.cli_script).to eq("custom/path/to/ssr.ts")
     end
 
-    it "has a timeout attribute" do
-      expect(subject).to respond_to(:timeout)
-      expect(subject).to respond_to(:timeout=)
-    end
-
-    it "has an ssr_stream_path attribute" do
-      expect(subject).to respond_to(:ssr_stream_path)
-      expect(subject).to respond_to(:ssr_stream_path=)
-    end
-
-    it "has an http_pool_size attribute" do
-      expect(subject).to respond_to(:http_pool_size)
-      expect(subject).to respond_to(:http_pool_size=)
-    end
-
-    it "has a stdio_cli_script attribute" do
-      expect(subject).to respond_to(:stdio_cli_script)
-      expect(subject).to respond_to(:stdio_cli_script=)
-    end
-
-    it "has a stdio_pool_size attribute" do
-      expect(subject).to respond_to(:stdio_pool_size)
-      expect(subject).to respond_to(:stdio_pool_size=)
-    end
-
-    it "has a stdio_timeout attribute" do
-      expect(subject).to respond_to(:stdio_timeout)
-      expect(subject).to respond_to(:stdio_timeout=)
+    it "shares a distinct instance per configuration" do
+      config = described_class.new
+      expect(config.stdio).not_to be(subject.stdio)
     end
   end
 end


### PR DESCRIPTION
## Summary

Reworks configuration handling to fix the awkward ENV coupling, the `SSR_` prefix, and stdio being as prominent as HTTP.

- `UniversalRenderer::Configuration` no longer reads environment variables. It exposes plain attributes with sensible defaults; ENV binding is left entirely to the host application.
- The generated initializer and install generator ship **plain defaults with no ENV binding**. The README shows how a user can bind `ENV` themselves with the suggested `UNIVERSAL_RENDERER_*` prefix.
- `config.engine` → `config.adapter` (clean break, no alias).
- Adapter-specific options nested under sub-objects: `config.http.*` and `config.stdio.*`.
- `ssr_url` → `url`, `ssr_stream_path` → `stream_path`, `http_pool_size` → `http.pool_size`, `stdio_pool_size` → `stdio.pool_size`, `stdio_timeout` → `stdio.timeout_ms`, `stdio_cli_script` → `stdio.cli_script`.
- The **stdio adapter is now experimental** and **lazily loaded**: it is only required when `config.adapter = :stdio` is set, so it never affects the default (HTTP) boot path. Verified via a scratch spec: the `Stdio` constant is never defined on the HTTP path.
- The generated initializer and install generator no longer mention stdio at all — a user only encounters it in the README.

## Breaking changes

All config attribute renames below are breaking (clean break, no aliases). Existing initializers need updating:

| Before | After |
| --- | --- |
| `config.engine` | `config.adapter` |
| `config.ssr_url` | `config.url` |
| `config.ssr_stream_path` | `config.stream_path` |
| `config.http_pool_size` | `config.http.pool_size` |
| `config.stdio_pool_size` | `config.stdio.pool_size` |
| `config.stdio_timeout` | `config.stdio.timeout_ms` |
| `config.stdio_cli_script` | `config.stdio.cli_script` |

The `SSR_*` env vars are no longer referenced anywhere in the gem.

## Verification

- `bundle exec rspec spec/units/` — 47 examples, 0 failures
- `bundle exec rspec spec/integration/multi_engine_contract_spec.rb -e STDIO` — 9 examples, 0 failures
- `rubocop` clean on all touched lib/spec files (benchmark offenses are pre-existing)
- Lazy-load behavior confirmed: stdio never loaded on the default HTTP path

## Notes

- The `SSR_MARKERS` TS enum and the `<!-- SSR_HEAD -->` / `<!-- SSR_BODY -->` placeholder strings are a separate, unrelated `SSR` namespace (HTML markers, not env config) and were intentionally left untouched.
- Benchmark scripts keep their `ENV` reads — those are runnable tooling scripts that parameterize runs, not shipped templates or defaults.

## Checklist

- [x] Configuration decoupled from ENV
- [x] `engine` → `adapter`
- [x] Nested `http`/`stdio` sub-objects
- [x] stdio marked experimental + lazily loaded
- [x] stdio removed from generated initializer/install generator (README only)
- [x] Generated initializer ships plain defaults
- [x] CHANGELOG entry added