### PR TITLE
Fix renderer security, streaming, and packaging issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
           bundler-cache: true
 
+      - name: Install RuboCop formatting configuration
+        run: npm install --workspaces=false --ignore-scripts --no-save --no-package-lock
+
       - name: Run RuboCop
         run: bundle exec rubocop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Run RuboCop
         run: bundle exec rubocop
-        continue-on-error: true
 
   ruby-tests:
     runs-on: ubuntu-latest
@@ -72,6 +71,10 @@ jobs:
       - name: Build TypeScript package with Bun
         working-directory: universal-renderer
         run: bun run build
+
+      - name: Verify package entry points
+        working-directory: universal-renderer
+        run: bun run test:package
 
       - name: Run TypeScript tests with Bun
         working-directory: universal-renderer
@@ -127,13 +130,7 @@ jobs:
   test-summary:
     runs-on: ubuntu-latest
     name: Test Summary Report
-    needs:
-      [
-        lint,
-        ruby-tests,
-        typescript-tests,
-        integration-tests,
-      ]
+    needs: [lint, ruby-tests, typescript-tests, integration-tests]
     if: always()
 
     steps:

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -15,6 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Security
+
+- Hardened SSR HTML sanitization against embedded documents, event handlers,
+  executable URL protocols, SVG data payloads, and meta refresh redirects.
+
+### Fixed
+
+- Corrected the NPM package's CommonJS entry points and included its MIT license.
+- Hardened HTTP request validation, asynchronous cleanup, streaming errors, and
+  client-disconnect handling.
+- Applied custom Express middleware before built-in SSR and health routes.
+- Prevented integration tests from leaking Bun servers and temporary installs.
+- Made RuboCop failures block CI and added package entry-point smoke tests.
+
+### Changed
+
+- Restored React 18 compatibility and made Vite a development-only dependency.
+
 ## 0.5.1 (Ruby Gem) - 2026-07-09
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :development do
   gem "rspec-rails", "~> 6.0"
   gem "webmock", "~> 3.18"
 
-  gem "prettier_print", "~> 1.2"
   gem "parallel", "< 2.0"
+  gem "prettier_print", "~> 1.2"
   gem "rubocop", "~> 1.60"
   gem "rubocop-factory_bot", "~> 2.25"
   gem "rubocop-rails", "~> 2.23"

--- a/bun.lock
+++ b/bun.lock
@@ -26,13 +26,13 @@
         "react-dom": "^19.2.7",
         "tsdown": "^0.22.4",
         "typescript": "^5.9.3",
+        "vite": "^6.4.3",
         "vitest": "^3.2.7",
       },
       "peerDependencies": {
         "express": "^4.22.2",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "vite": "^6.4.3",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
       },
     },
   },
@@ -373,7 +373,7 @@
 
     "express": ["express@4.22.2", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.5", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.15.1", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q=="],
 
-    "fdir": ["fdir@6.4.4", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, ""],
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "finalhandler": ["finalhandler@1.3.1", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "2.4.1", "parseurl": "~1.3.3", "statuses": "2.0.1", "unpipe": "~1.0.0" } }, "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ=="],
 
@@ -613,7 +613,7 @@
 
     "vary": ["vary@1.1.2", "", {}, ""],
 
-    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "yaml"], "bin": "bin/vite.js" }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+    "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": "vite-node.mjs" }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
@@ -675,21 +675,19 @@
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
-    "tinyglobby/fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
-
     "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
-    "vite/picomatch": ["picomatch@4.0.2", "", {}, ""],
-
-    "vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, ""],
 
     "vite-node/cac": ["cac@6.7.14", "", {}, ""],
 
     "vite-node/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, ""],
 
+    "vite-node/vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "yaml"], "bin": "bin/vite.js" }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
     "vitest/debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, ""],
 
     "vitest/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "vitest/vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "yaml"], "bin": "bin/vite.js" }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, ""],
 
@@ -763,6 +761,18 @@
 
     "vite-node/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "vite-node/vite/fdir": ["fdir@6.4.4", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, ""],
+
+    "vite-node/vite/picomatch": ["picomatch@4.0.2", "", {}, ""],
+
+    "vite-node/vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, ""],
+
     "vitest/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "vitest/vite/fdir": ["fdir@6.4.4", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, ""],
+
+    "vitest/vite/picomatch": ["picomatch@4.0.2", "", {}, ""],
+
+    "vitest/vite/tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, ""],
   }
 }

--- a/lib/universal_renderer/ssr/scrubber.rb
+++ b/lib/universal_renderer/ssr/scrubber.rb
@@ -15,8 +15,8 @@ module UniversalRenderer
         srcset xlink:href
       ].freeze
       ALLOWED_PROTOCOLS = %w[http https mailto tel].freeze
-      DANGEROUS_PROTOCOL = /(?:javascript|vbscript):/i
-      DANGEROUS_DATA = %r{data:(?:text/html|application/xhtml\+xml|image/svg\+xml)}i
+      DANGEROUS_PROTOCOL = /\A(?:javascript|vbscript):/i
+      DANGEROUS_DATA = %r{\Adata:(?:text/html|application/xhtml\+xml|image/svg\+xml)}i
       SAFE_DATA_IMAGE = %r{\Adata:image/(?:avif|gif|jpeg|png|webp);base64,}i
 
       def initialize

--- a/lib/universal_renderer/ssr/scrubber.rb
+++ b/lib/universal_renderer/ssr/scrubber.rb
@@ -1,61 +1,76 @@
+require "cgi"
 require "loofah"
 
 module UniversalRenderer
   module SSR
+    # Removes executable content from HTML returned by the SSR service while
+    # preserving the elements and data attributes needed to hydrate an app.
     class Scrubber < ::Loofah::Scrubber
+      BLOCKED_ELEMENTS = %w[
+        base embed frame frameset iframe object script
+        animate animatemotion animatetransform set
+      ].freeze
+      URI_ATTRIBUTES = %w[
+        action background cite codebase data formaction href longdesc poster src
+        srcset xlink:href
+      ].freeze
+      ALLOWED_PROTOCOLS = %w[http https mailto tel].freeze
+      DANGEROUS_PROTOCOL = /(?:javascript|vbscript):/i
+      DANGEROUS_DATA = %r{data:(?:text/html|application/xhtml\+xml|image/svg\+xml)}i
+      SAFE_DATA_IMAGE = %r{\Adata:image/(?:avif|gif|jpeg|png|webp);base64,}i
+
       def initialize
         super
         @direction = :top_down
       end
 
       def scrub(node)
-        # Primary actions: stop if script, continue if a passthrough tag, otherwise clean attributes.
-        return Loofah::Scrubber::STOP if handle_script_node(node) # Checks for <script> and removes it
+        return Loofah::Scrubber::CONTINUE unless node.element?
 
-        # Allows <link rel="stylesheet">, <style>, <meta> to pass through this scrubber.
-        return Loofah::Scrubber::CONTINUE if passthrough_node?(node)
+        if blocked_element?(node) || refreshing_meta?(node)
+          node.remove
+          return Loofah::Scrubber::STOP
+        end
 
-        # For all other nodes, clean potentially harmful attributes.
         clean_attributes(node)
-        # Default Loofah behavior (CONTINUE for children) applies if not returned earlier.
+        Loofah::Scrubber::CONTINUE
       end
 
       private
 
-      # Handles <script> tags: removes them and returns true if a script node was processed.
-      def handle_script_node(node)
-        return false unless node.name == "script"
-
-        node.remove
-        true # Indicates the node was a script and has been handled.
+      def blocked_element?(node)
+        BLOCKED_ELEMENTS.include?(node.name.downcase)
       end
 
-      # Checks if the node is a type that should bypass detailed attribute scrubbing.
-      def passthrough_node?(node)
-        (node.name == "link" && node["rel"]&.to_s&.downcase == "stylesheet") ||
-          %w[style meta].include?(node.name)
+      def refreshing_meta?(node)
+        node.name == "meta" && node["http-equiv"]&.casecmp?("refresh")
       end
 
-      # Orchestrates the cleaning of attributes for a given node.
       def clean_attributes(node)
-        remove_javascript_href(node)
-        remove_event_handlers(node)
+        node.attributes.each_key do |attribute_name|
+          normalized_name = attribute_name.to_s.downcase
+          remove_attribute =
+            normalized_name.start_with?("on") ||
+              normalized_name == "srcdoc" ||
+              (URI_ATTRIBUTES.include?(normalized_name) &&
+                unsafe_uri?(node[attribute_name].to_s, normalized_name))
+
+          node.remove_attribute(attribute_name) if remove_attribute
+        end
       end
 
-      # Removes "javascript:" hrefs from <a> tags.
-      def remove_javascript_href(node)
-        return unless node.name == "a" && node["href"]
-        href = node["href"].to_s.downcase
-        node.remove_attribute("href") if href.start_with?("javascript:")
-      end
+      def unsafe_uri?(value, attribute_name)
+        normalized = CGI.unescapeHTML(value).gsub(/[\u0000-\u0020]/, "")
+        return true if normalized.match?(DANGEROUS_PROTOCOL)
+        return true if normalized.match?(DANGEROUS_DATA)
 
-      # Removes "on*" event handler attributes from any node.
-      def remove_event_handlers(node)
-        attrs_to_remove =
-          node.attributes.keys.select do |name|
-            name.to_s.downcase.start_with?("on")
-          end
-        attrs_to_remove.each { |attr_name| node.remove_attribute(attr_name) }
+        scheme = normalized[/\A([a-z][a-z0-9+.-]*):/i, 1]
+        return false unless scheme
+        return false if ALLOWED_PROTOCOLS.include?(scheme.downcase)
+        return false if %w[src srcset].include?(attribute_name) &&
+                        normalized.match?(SAFE_DATA_IMAGE)
+
+        true
       end
     end
   end

--- a/spec/integration/server_helpers.rb
+++ b/spec/integration/server_helpers.rb
@@ -29,58 +29,74 @@ module IntegrationHelpers
       ensure_port_available!(hostname, port)
       config = config.dup
 
-      # Create a temporary directory for the test server
       server_dir = HttpExpressServerGenerator.create_directory
+      process = nil
 
-      # Write the test server configuration
-      HttpExpressServerGenerator.write_files(
-        server_dir,
-        port: port,
-        hostname: hostname,
-        **config
-      )
-
-      # Spawn the SSR process
-      command = %w[bun server.mjs]
-
-      process =
-        Process.spawn(
-          { "NODE_ENV" => "test" },
-          *command,
-          chdir: server_dir,
-          out: config[:verbose] || !ENV["CI"] ? $stdout : File::NULL,
-          err: config[:verbose] || !ENV["CI"] ? $stderr : File::NULL,
-          pgroup: true
+      begin
+        HttpExpressServerGenerator.write_files(
+          server_dir,
+          port: port,
+          hostname: hostname,
+          **config
         )
 
-      # Wait for server to be ready
-      wait_for_server(hostname, port)
+        process =
+          Process.spawn(
+            { "NODE_ENV" => "test" },
+            "bun",
+            "server.mjs",
+            chdir: server_dir,
+            out: config[:verbose] || !ENV["CI"] ? $stdout : File::NULL,
+            err: config[:verbose] || !ENV["CI"] ? $stderr : File::NULL,
+            pgroup: true
+          )
 
-      # Store cleanup info
-      @spawned_servers ||= []
-      @spawned_servers << { process: process, directory: server_dir }
-
-      process
+        wait_for_server(hostname, port)
+        ServerHelpers.spawned_servers << {
+          process: process,
+          directory: server_dir
+        }
+        process
+      rescue StandardError
+        terminate_server(process) if process
+        FileUtils.rm_rf(server_dir)
+        raise
+      end
     end
 
-    # Stops all spawned SSR servers and cleans up resources
+    def self.spawned_servers
+      @spawned_servers ||= []
+    end
+
+    # Stops all spawned SSR servers and cleans up resources. The registry is
+    # module-scoped because RSpec runs before(:all), examples, and after(:all)
+    # on different object instances.
     def cleanup_ssr_servers
-      return unless @spawned_servers
-
-      @spawned_servers.each do |server_info|
-        begin
-          # Kill the process group to ensure all child processes are terminated
-          Process.kill("TERM", -Process.getpgid(server_info[:process]))
-          Process.waitpid(server_info[:process], Process::WNOHANG)
-        rescue Errno::ESRCH, Errno::ECHILD
-          # Process already terminated
-        end
-
-        # Clean up temporary directory
+      ServerHelpers.spawned_servers.each do |server_info|
+        terminate_server(server_info[:process])
+      ensure
         FileUtils.rm_rf(server_info[:directory])
       end
+    ensure
+      ServerHelpers.spawned_servers.clear
+    end
 
-      @spawned_servers.clear
+    def terminate_server(process)
+      process_group = Process.getpgid(process)
+      Process.kill("TERM", -process_group)
+
+      Timeout.timeout(5) { Process.waitpid(process) }
+    rescue Timeout::Error
+      force_terminate_server(process, process_group)
+    rescue Errno::ESRCH, Errno::ECHILD
+      # Process already terminated and reaped.
+    end
+
+    def force_terminate_server(process, process_group)
+      Process.kill("KILL", -process_group)
+      Process.waitpid(process)
+    rescue Errno::ESRCH, Errno::ECHILD
+      # Process exited between the timeout and forced termination.
     end
 
     # Waits for a server to be responsive on the given hostname and port

--- a/spec/units/client/stream_execution_spec.rb
+++ b/spec/units/client/stream_execution_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe UniversalRenderer::Client::Stream::Execution do
 
   before do
     allow(UniversalRenderer).to receive(:logger).and_return(Rails.logger)
-    allow(UniversalRenderer).to receive(:log) do |&block|
-      block.call(Rails.logger)
-    end
+    allow(UniversalRenderer).to receive(:log).and_yield(Rails.logger)
     allow(Rails.logger).to receive(:error)
   end
 

--- a/spec/units/ssr/scrubber_spec.rb
+++ b/spec/units/ssr/scrubber_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UniversalRenderer::SSR::Scrubber do
+  let(:view_class) do
+    Class.new { include ActionView::Helpers::SanitizeHelper }
+  end
+  let(:view) { view_class.new }
+
+  def sanitize(html)
+    view.sanitize(html, scrubber: described_class.new)
+  end
+
+  it "removes executable elements and embedded documents" do
+    html = <<~HTML
+      <script>alert(1)</script>
+      <iframe srcdoc="&lt;script&gt;alert(1)&lt;/script&gt;"></iframe>
+      <object data="https://example.test/payload"></object>
+      <svg><animate attributeName="href" values="javascript:alert(1)"></animate></svg>
+      <div>safe</div>
+    HTML
+
+    result = sanitize(html)
+
+    expect(result).to include("<div>safe</div>")
+    expect(result).not_to include("script", "iframe", "object", "animate")
+  end
+
+  it "removes event handlers from every element, including head elements" do
+    html = <<~HTML
+      <style onload="alert(1)">body { color: red }</style>
+      <link rel="stylesheet" href="/app.css" onload="alert(1)">
+      <meta name="description" content="safe" onmouseover="alert(1)">
+      <div onclick="alert(1)">safe</div>
+    HTML
+
+    result = sanitize(html)
+
+    expect(result).to include("<style>body { color: red }</style>")
+    expect(result).to include('rel="stylesheet" href="/app.css"')
+    expect(result).to include('name="description" content="safe"')
+    expect(result).not_to include("onload", "onmouseover", "onclick")
+  end
+
+  it "removes dangerous URL protocols and meta refresh redirects" do
+    html = <<~HTML
+      <a href="  javascript:alert(1)">link</a>
+      <img src="data:image/svg+xml,&lt;svg onload='alert(1)'/&gt;">
+      <form action="vbscript:alert(1)"></form>
+      <meta http-equiv="refresh" content="0;url=https://evil.test">
+    HTML
+
+    result = sanitize(html)
+
+    expect(result).to include("<a>link</a>", "<img>", "<form></form>")
+    expect(result).not_to include("javascript", "vbscript", "data:", "refresh")
+  end
+
+  it "preserves hydration attributes and safe asset URLs" do
+    html = <<~HTML
+      <main id="root" class="app" data-page="home" aria-live="polite">
+        <img src="https://example.test/image.png" alt="Example">
+      </main>
+    HTML
+
+    expect(sanitize(html).strip).to eq(html.strip)
+  end
+end

--- a/spec/units/ssr/scrubber_spec.rb
+++ b/spec/units/ssr/scrubber_spec.rb
@@ -57,9 +57,11 @@ RSpec.describe UniversalRenderer::SSR::Scrubber do
     expect(result).not_to include("javascript", "vbscript", "data:", "refresh")
   end
 
-  it "preserves hydration attributes and safe asset URLs" do
+  it "preserves hydration attributes and safe URLs" do
     html = <<~HTML
       <main id="root" class="app" data-page="home" aria-live="polite">
+        <a href="https://example.test/docs/javascript:guide">Protocol guide</a>
+        <a href="https://example.test/?example=data:text/html">Data URL guide</a>
         <img src="https://example.test/image.png" alt="Example">
       </main>
     HTML

--- a/universal-renderer/LICENSE
+++ b/universal-renderer/LICENSE
@@ -1,0 +1,20 @@
+Copyright thaske
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/universal-renderer/package.json
+++ b/universal-renderer/package.json
@@ -16,21 +16,22 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "test:node": "vitest run"
+    "test:node": "vitest run",
+    "test:package": "node scripts/test-package.mjs"
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "require": "./dist/index.cjs"
     },
     "./http": {
       "types": "./dist/http/index.d.mts",
       "import": "./dist/http/index.mjs",
-      "require": "./dist/http/index.js"
+      "require": "./dist/http/index.cjs"
     }
   },
   "files": [
@@ -40,9 +41,8 @@
   ],
   "peerDependencies": {
     "express": "^4.22.2",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "vite": "^6.4.3"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
@@ -59,6 +59,7 @@
     "react-dom": "^19.2.7",
     "tsdown": "^0.22.4",
     "typescript": "^5.9.3",
+    "vite": "^6.4.3",
     "vitest": "^3.2.7"
   },
   "keywords": [

--- a/universal-renderer/scripts/test-package.mjs
+++ b/universal-renderer/scripts/test-package.mjs
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const esmMain = await import("universal-renderer");
+const esmHttp = await import("universal-renderer/http");
+const cjsMain = require("universal-renderer");
+const cjsHttp = require("universal-renderer/http");
+
+for (const entry of [esmMain, esmHttp, cjsMain, cjsHttp]) {
+  assert.equal(typeof entry.createServer, "function");
+}
+
+console.log("ESM and CommonJS package entry points are valid");

--- a/universal-renderer/src/http/handlers.test.ts
+++ b/universal-renderer/src/http/handlers.test.ts
@@ -200,6 +200,52 @@ describe("HTTP handler hardening", () => {
     }
   });
 
+  it("cleans up if the client disconnects while setup is pending", async () => {
+    const cleanup = vi.fn(async () => {});
+    let setupStarted!: () => void;
+    let finishSetup!: () => void;
+    const setupHasStarted = new Promise<void>((resolve) => {
+      setupStarted = resolve;
+    });
+    const setupCanFinish = new Promise<void>((resolve) => {
+      finishSetup = resolve;
+    });
+    const app = await createServer({
+      ...basicOptions(),
+      setup: async () => {
+        setupStarted();
+        await setupCanFinish;
+        return { app: createElement("div", null, "streamed") };
+      },
+      cleanup,
+      streamCallbacks: { node: (context) => context.app },
+    });
+    const server = await listen(app);
+
+    try {
+      const clientRequest = request(`${server.baseUrl}/stream`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      });
+      clientRequest.once("error", () => {});
+      clientRequest.end(
+        JSON.stringify({
+          url: "/test",
+          template: "<html><body><!-- SSR_BODY --></body></html>",
+        }),
+      );
+
+      await setupHasStarted;
+      clientRequest.destroy();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      finishSetup();
+
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+    } finally {
+      await server.close();
+    }
+  });
+
   it("cleans up when React cannot produce a shell", async () => {
     const cleanup = vi.fn(async () => {});
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/universal-renderer/src/http/handlers.test.ts
+++ b/universal-renderer/src/http/handlers.test.ts
@@ -1,0 +1,232 @@
+import { createElement } from "react";
+import type { AddressInfo } from "node:net";
+import { request, type Server } from "node:http";
+import { Transform } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createServer } from "./server";
+
+async function listen(app: Awaited<ReturnType<typeof createServer>>) {
+  const server = await new Promise<Server>((resolve) => {
+    const listeningServer = app.listen(0, "127.0.0.1", () => {
+      resolve(listeningServer);
+    });
+  });
+  const { port } = server.address() as AddressInfo;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function basicOptions() {
+  return {
+    setup: async (url: string, props: Record<string, any>) => ({ url, props }),
+    render: async () => ({ body: "<div>Rendered</div>" }),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("HTTP handler hardening", () => {
+  it("applies custom middleware to built-in routes", async () => {
+    const app = await createServer({
+      ...basicOptions(),
+      middleware: (_req, res, next) => {
+        res.setHeader("x-custom", "present");
+        next();
+      },
+    });
+    const server = await listen(app);
+
+    try {
+      const health = await fetch(`${server.baseUrl}/health`);
+      const render = await fetch(`${server.baseUrl}/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: "/test" }),
+      });
+
+      expect(health.headers.get("x-custom")).toBe("present");
+      expect(render.headers.get("x-custom")).toBe("present");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("returns 400 for a streaming request without a usable JSON body", async () => {
+    const app = await createServer({
+      ...basicOptions(),
+      streamCallbacks: {
+        node: () => createElement("div", null, "streamed"),
+      },
+    });
+    const server = await listen(app);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/stream`, {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: "not json",
+      });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({
+        error: "URL string is required",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("handles asynchronous streaming head failures and cleans up", async () => {
+    const cleanup = vi.fn(async () => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const app = await createServer({
+      ...basicOptions(),
+      cleanup,
+      streamCallbacks: {
+        node: () => createElement("div", null, "streamed"),
+        head: async () => {
+          throw new Error("head failed");
+        },
+      },
+    });
+    const server = await listen(app);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/stream`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          url: "/test",
+          template:
+            "<html><!-- SSR_HEAD --><body><!-- SSR_BODY --></body></html>",
+        }),
+      });
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({ error: "head failed" });
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("contains cleanup failures after a blocking response", async () => {
+    const cleanupError = new Error("cleanup failed");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const app = await createServer({
+      ...basicOptions(),
+      cleanup: async () => {
+        throw cleanupError;
+      },
+    });
+    const server = await listen(app);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: "/test" }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toMatchObject({
+        body: "<div>Rendered</div>",
+      });
+      await vi.waitFor(() =>
+        expect(consoleError).toHaveBeenCalledWith(
+          "[SSR] Cleanup error:",
+          cleanupError,
+        ),
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("aborts rendering and cleans up when the client disconnects", async () => {
+    const cleanup = vi.fn(async () => {});
+    const app = await createServer({
+      ...basicOptions(),
+      cleanup,
+      streamCallbacks: {
+        node: () => createElement("div", null, "streamed"),
+        transform: () =>
+          new Transform({
+            transform(chunk, _encoding, callback) {
+              setTimeout(() => callback(null, chunk), 100);
+            },
+          }),
+      },
+    });
+    const server = await listen(app);
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const clientRequest = request(
+          `${server.baseUrl}/stream`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+          },
+          (response) => {
+            response.once("data", () => {
+              response.destroy();
+              resolve();
+            });
+          },
+        );
+        clientRequest.once("error", reject);
+        clientRequest.end(
+          JSON.stringify({
+            url: "/test",
+            template: "<html><body><!-- SSR_BODY --></body></html>",
+          }),
+        );
+      });
+
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("cleans up when React cannot produce a shell", async () => {
+    const cleanup = vi.fn(async () => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const Broken = () => {
+      throw new Error("shell failed");
+    };
+    const app = await createServer({
+      ...basicOptions(),
+      cleanup,
+      streamCallbacks: { node: () => createElement(Broken) },
+    });
+    const server = await listen(app);
+
+    try {
+      const response = await fetch(`${server.baseUrl}/stream`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          url: "/test",
+          template: "<html><body><!-- SSR_BODY --></body></html>",
+        }),
+      });
+
+      expect(response.status).toBe(500);
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/universal-renderer/src/http/handlers/error.ts
+++ b/universal-renderer/src/http/handlers/error.ts
@@ -2,6 +2,7 @@ import type { NextFunction, Request, Response } from "express";
 
 export class HttpError extends Error {
   statusCode?: number;
+  status?: number;
 
   constructor(message: string, statusCode: number = 500) {
     super(message);
@@ -18,15 +19,12 @@ export class HttpError extends Error {
  * @returns Error handler function
  */
 export function createErrorHandler() {
-  return (
-    err: HttpError,
-    _req: Request,
-    res: Response,
-    _next: NextFunction,
-  ) => {
+  return (err: HttpError, _req: Request, res: Response, next: NextFunction) => {
+    if (res.headersSent) return next(err);
+
     const isDev = process.env.NODE_ENV !== "production";
 
-    const statusCode = err.statusCode || 500;
+    const statusCode = err.statusCode || err.status || 500;
 
     if (statusCode >= 500) {
       console.error("[SSR] Express Server Error:", err);

--- a/universal-renderer/src/http/handlers/ssr.ts
+++ b/universal-renderer/src/http/handlers/ssr.ts
@@ -26,10 +26,21 @@ export function createSSRHandler<TContext extends Record<string, any>>(
     let context: TContext | undefined;
 
     try {
+      if (
+        !req.body ||
+        typeof req.body !== "object" ||
+        Array.isArray(req.body)
+      ) {
+        throw new HttpError("JSON request body is required", 400);
+      }
+
       const { url, props = {} } = req.body;
 
       if (!url || typeof url !== "string") {
         throw new HttpError("URL string is required", 400);
+      }
+      if (props === null || typeof props !== "object" || Array.isArray(props)) {
+        throw new HttpError("Props must be an object", 400);
       }
 
       context = await options.setup(url, props);
@@ -44,7 +55,13 @@ export function createSSRHandler<TContext extends Record<string, any>>(
       return next(error);
     } finally {
       if (context && options.cleanup) {
-        await options.cleanup(context);
+        try {
+          await options.cleanup(context);
+        } catch (error) {
+          // Cleanup must never turn a completed response into an unhandled
+          // rejection. Rendering errors have already been delegated above.
+          console.error("[SSR] Cleanup error:", error);
+        }
       }
     }
   };

--- a/universal-renderer/src/http/handlers/stream.ts
+++ b/universal-renderer/src/http/handlers/stream.ts
@@ -69,6 +69,19 @@ export function createStreamHandler<TContext extends Record<string, any>>(
     let props: Record<string, any>;
     let template: string;
 
+    // Listen before setup: setup may be asynchronous, and a client can
+    // disconnect before it returns a context that must be cleaned up.
+    res.once("finish", () => {
+      void cleanup();
+    });
+    res.once("close", () => {
+      if (!res.writableFinished) {
+        stopped = true;
+        abortRender?.();
+        void cleanup();
+      }
+    });
+
     try {
       if (
         !req.body ||
@@ -95,6 +108,11 @@ export function createStreamHandler<TContext extends Record<string, any>>(
 
       context = await options.setup(url, props);
 
+      if (stopped || res.destroyed) {
+        await cleanup();
+        return;
+      }
+
       if (streamCallbacks.node) {
         reactNode = streamCallbacks.node(context);
       } else if ("app" in context) {
@@ -108,17 +126,6 @@ export function createStreamHandler<TContext extends Record<string, any>>(
       await cleanup();
       return next(error);
     }
-
-    res.once("finish", () => {
-      void cleanup();
-    });
-    res.once("close", () => {
-      if (!res.writableFinished) {
-        stopped = true;
-        abortRender?.();
-        void cleanup();
-      }
-    });
 
     const startStreaming = async (
       pipe: (destination: NodeJS.WritableStream) => void,

--- a/universal-renderer/src/http/handlers/stream.ts
+++ b/universal-renderer/src/http/handlers/stream.ts
@@ -7,6 +7,10 @@ import { SSR_MARKERS } from "../../constants";
 import type { ExpressStreamHandlerOptions } from "../types";
 import { HttpError } from "./error";
 
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 /**
  * Creates a streaming Server-Side Rendering route handler for React 18+ streaming SSR.
  *
@@ -26,20 +30,65 @@ export function createStreamHandler<TContext extends Record<string, any>>(
   const { streamCallbacks } = options;
 
   return async (req, res, next: NextFunction) => {
-    const { url = "", props = {}, template = "" } = req.body;
-
     let context: TContext | undefined;
     let reactNode: ReactNode | undefined;
+    let abortRender: (() => void) | undefined;
+    let cleanupStarted = false;
+    let stopped = false;
+    let didRenderError = false;
+
+    const cleanup = async () => {
+      if (cleanupStarted || !context || !options.cleanup) return;
+
+      cleanupStarted = true;
+      try {
+        await options.cleanup(context);
+      } catch (error) {
+        // Cleanup runs after the response lifecycle and cannot safely be sent
+        // through Express once headers have been written.
+        console.error("[SSR] Cleanup error:", error);
+      }
+    };
+
+    const stopWithError = (error: unknown) => {
+      if (stopped) return;
+
+      stopped = true;
+      abortRender?.();
+      void cleanup();
+
+      const normalizedError = asError(error);
+      if (res.headersSent) {
+        if (!res.destroyed) res.destroy(normalizedError);
+      } else {
+        next(normalizedError);
+      }
+    };
+
+    let url: string;
+    let props: Record<string, any>;
+    let template: string;
 
     try {
-      if (!url) {
-        throw new HttpError("URL is required", 400);
+      if (
+        !req.body ||
+        typeof req.body !== "object" ||
+        Array.isArray(req.body)
+      ) {
+        throw new HttpError("JSON request body is required", 400);
       }
 
-      if (!template) {
-        throw new HttpError("Template is required", 400);
-      }
+      ({ url, props = {}, template } = req.body);
 
+      if (!url || typeof url !== "string") {
+        throw new HttpError("URL string is required", 400);
+      }
+      if (props === null || typeof props !== "object" || Array.isArray(props)) {
+        throw new HttpError("Props must be an object", 400);
+      }
+      if (!template || typeof template !== "string") {
+        throw new HttpError("Template string is required", 400);
+      }
       if (!template.includes(SSR_MARKERS.BODY)) {
         throw new HttpError(`Template missing ${SSR_MARKERS.BODY} marker`, 400);
       }
@@ -47,53 +96,77 @@ export function createStreamHandler<TContext extends Record<string, any>>(
       context = await options.setup(url, props);
 
       if (streamCallbacks.node) {
-        reactNode = streamCallbacks.node(context!);
-      } else if (context && "app" in context) {
+        reactNode = streamCallbacks.node(context);
+      } else if ("app" in context) {
         reactNode = context.app;
-      } else if (context && "jsx" in context) {
+      } else if ("jsx" in context) {
         reactNode = context.jsx;
       } else {
         throw new HttpError("No app callback provided", 400);
       }
     } catch (error) {
+      await cleanup();
       return next(error);
     }
 
-    const { pipe } = renderToPipeableStream(reactNode, {
-      async onShellReady() {
-        res.setHeader("content-type", "text/html");
-
-        const [head, tail] = template.split(SSR_MARKERS.BODY);
-
-        const finalHead = await streamCallbacks.head?.(context!);
-        res.write(head.replace(SSR_MARKERS.HEAD, finalHead ?? ""));
-
-        const stream = new PassThrough();
-        const transform = streamCallbacks.transform?.(context!);
-
-        // Watch the end of the pipeline, not the source: with a transform,
-        // the PassThrough can end while the transform still holds buffered
-        // output, and writing the tail then would interleave it into the body.
-        const output = transform ? stream.pipe(transform) : stream;
-        output.pipe(res, { end: false });
-        pipe(stream);
-
-        output.on("end", () => {
-          res.end(tail);
-        });
-
-        res.on("finish", () => {
-          if (context) options.cleanup?.(context);
-        });
-      },
-      onShellError(error: unknown) {
-        console.error("[SSR] Shell error:", error);
-        if (!res.headersSent) next(error);
-      },
-      onError(error: unknown) {
-        console.error("[SSR] Stream error:", error);
-        if (!res.headersSent) next(error);
-      },
+    res.once("finish", () => {
+      void cleanup();
     });
+    res.once("close", () => {
+      if (!res.writableFinished) {
+        stopped = true;
+        abortRender?.();
+        void cleanup();
+      }
+    });
+
+    const startStreaming = async (
+      pipe: (destination: NodeJS.WritableStream) => void,
+    ) => {
+      const bodyMarkerIndex = template.indexOf(SSR_MARKERS.BODY);
+      const head = template.slice(0, bodyMarkerIndex);
+      const tail = template.slice(bodyMarkerIndex + SSR_MARKERS.BODY.length);
+      const finalHead = await streamCallbacks.head?.(context);
+
+      if (stopped || res.destroyed) return;
+
+      if (didRenderError) res.status(500);
+      res.setHeader("content-type", "text/html");
+      res.write(head.replace(SSR_MARKERS.HEAD, finalHead ?? ""));
+
+      const stream = new PassThrough();
+      const transform = streamCallbacks.transform?.(context);
+      const output = transform ? stream.pipe(transform) : stream;
+
+      const handleOutputError = (error: unknown) => stopWithError(error);
+      stream.once("error", handleOutputError);
+      if (output !== stream) output.once("error", handleOutputError);
+
+      output.pipe(res, { end: false });
+      output.once("end", () => {
+        if (!stopped && !res.destroyed) res.end(tail);
+      });
+
+      pipe(stream);
+    };
+
+    try {
+      const renderer = renderToPipeableStream(reactNode, {
+        onShellReady() {
+          void startStreaming(renderer.pipe).catch(stopWithError);
+        },
+        onShellError(error: unknown) {
+          console.error("[SSR] Shell error:", error);
+          stopWithError(error);
+        },
+        onError(error: unknown) {
+          didRenderError = true;
+          console.error("[SSR] Stream error:", error);
+        },
+      });
+      abortRender = renderer.abort;
+    } catch (error) {
+      stopWithError(error);
+    }
   };
 }

--- a/universal-renderer/src/http/server.ts
+++ b/universal-renderer/src/http/server.ts
@@ -60,6 +60,12 @@ export async function createServer<
   app.use(express.json({ limit: "50mb" }));
   app.use(express.urlencoded({ extended: true }));
 
+  // Apply custom middleware before the built-in routes so authentication,
+  // request decoration, and response headers affect SSR and health requests.
+  if (options.middleware) {
+    app.use(options.middleware);
+  }
+
   // Health check endpoint using the health handler factory
   app.get("/health", createHealthHandler());
 
@@ -80,11 +86,6 @@ export async function createServer<
       error: options.error,
     });
     app.post("/stream", streamHandler);
-  }
-
-  // Custom middleware
-  if (options.middleware) {
-    app.use(options.middleware);
   }
 
   // Handle 404 - Not Found

--- a/universal-renderer/src/http/types.ts
+++ b/universal-renderer/src/http/types.ts
@@ -79,7 +79,7 @@ export type ExpressServerOptions<
 
   /**
    * Optional Express middleware to be applied to the server.
-   * This middleware will be applied after the built-in middleware but before the error handler.
+   * This middleware runs after request parsing and before the built-in health and SSR routes.
    *
    * @example
    * ```typescript

--- a/universal-renderer/src/types.ts
+++ b/universal-renderer/src/types.ts
@@ -62,7 +62,7 @@ export type BaseHandlerOptions<TContext extends Record<string, any>> = {
    * Optional cleanup function called after rendering is complete.
    * @param context - The context object returned by the setup function
    */
-  cleanup?: (context: TContext) => void;
+  cleanup?: (context: TContext) => Promise<void> | void;
 };
 
 /**


### PR DESCRIPTION
## Summary

- harden SSR HTML sanitization against executable elements, event handlers, unsafe URL protocols, SVG data payloads, and meta refresh redirects
- fix CommonJS package exports, include the NPM license, restore React 18 peer compatibility, and move Vite to development dependencies
- validate HTTP payloads and harden blocking/streaming cleanup, shell failures, transform errors, and client disconnect handling
- apply custom middleware before built-in health and SSR routes
- stop integration tests from leaking Bun processes and temporary dependency installations
- make lint failures block CI and smoke-test ESM/CommonJS package entry points

## Tests

- `bun run --filter universal-renderer build`
- `bun run --filter universal-renderer test:package`
- `bun run --filter universal-renderer test` (10 examples)
- `bundle exec rspec spec/units` (21 examples)
- `bundle exec rspec spec/integration` (29 examples)
- `bundle exec rubocop`
- Prettier check
- React 18 ESM/CommonJS tarball smoke test

No Bun server processes or integration temporary directories remained after the integration suite.
